### PR TITLE
試練１が表示されない

### DIFF
--- a/files/scripts/ascension_manager.lua
+++ b/files/scripts/ascension_manager.lua
@@ -19,7 +19,8 @@ function AscensionManager:init()
   self:load_progress()
 
   -- Activate ascension if current_level is set
-  if self.current_level > 0 and self.current_level <= self.highest_level then
+  local newgame = self.current_level == 1 and self.highest_level == 0
+  if newgame or (self.current_level > 0 and self.current_level <= self.highest_level) then
     self:activate_ascension(self.current_level)
     log:info("Start Ascension %d", self.current_level)
   else


### PR DESCRIPTION
MODを入れた直後（self.current_level == 1 and self.highest_level == 0）のとき、activate_ascension()が実行されず、画面右上にA1のアイコンが出ず、画面中央に「試練１」出ていませんでした

直し方が合っているか分からないですが、とりあえずこの修正で画面右上にA1のアイコンが出て、画面中央に「試練１」出るようにはなりました
（追記　１クリアした後、新規ゲームするとまた１で開始していたので、直し方おかしいかもしれません）