### PR TITLE
:hammer: fix: use VelocityComponent to modify projectile speed in a13

### DIFF
--- a/files/scripts/ascensions/a13_increase_speed_on_shot_append.lua
+++ b/files/scripts/ascensions/a13_increase_speed_on_shot_append.lua
@@ -6,13 +6,11 @@ local ELITE_PROJECTILE_SPEED = 1.5
 -- selene: allow(unused_variable)
 function shot(projectile_entity_id)
   -- log:debug("elite enemy shot")
-  local projectile_component_id = EntityGetFirstComponent(projectile_entity_id, "ProjectileComponent")
-  if not projectile_component_id then
+  local velocity_component_id = EntityGetFirstComponent(projectile_entity_id, "VelocityComponent")
+  if not velocity_component_id then
     return
   end
-  local speed_min = ComponentGetValue2(projectile_component_id, "speed_min")
-  local speed_max = ComponentGetValue2(projectile_component_id, "speed_max")
 
-  ComponentSetValue2(projectile_component_id, "speed_min", speed_min * ELITE_PROJECTILE_SPEED)
-  ComponentSetValue2(projectile_component_id, "speed_max", speed_max * ELITE_PROJECTILE_SPEED)
+  local velocity_x, velocity_y = ComponentGetValue2(velocity_component_id, "mVelocity")
+  ComponentSetValue2(velocity_component_id, "mVelocity", velocity_x * ELITE_PROJECTILE_SPEED, velocity_y * ELITE_PROJECTILE_SPEED)
 end


### PR DESCRIPTION
Hi @den3606,

First of all, thank you for creating this interesting mod!

While studying the implementation with my friends, we noticed a few issues. This pull request addresses one of them, regarding how projectile speed is modified for Ascension 13.

### The Problem

The `shot()` function, triggered by `script_shot`, is executed relatively late in the engine's `shoot_projectile` process. By this point, the projectile's `VelocityComponent` has already been initialized with a starting velocity derived from the `speed_min` and `speed_max` values in its `ProjectileComponent`.

As a result, the current code in `a13_increase_speed_on_shot_append.lua` modifies the `ProjectileComponent` values, but this change doesn't affect the speed of the projectile that was just fired, as those source values are unlikely to be used again after `shoot_projectile`.

(Interestingly, this seems to be a common pitfall, as a similar logic issue can be found in the vanilla game file `data/scripts/perks/fast_projectiles_enemy.lua`.)

### The Fix

This PR corrects the logic by directly modifying the `mVelocity` values on the projectile's **`VelocityComponent`** instead. This directly changes the velocity of the specific projectile that was fired, ensuring the `ELITE_PROJECTILE_SPEED` multiplier is correctly applied.

This approach is safe and semantically achieves the original goal of modifying projectile speed in A13. It should not cause unintended side effects, as it does not interfere with other related properties. For instance, `mInitialSpeed` in `ProjectileComponent` is not yet set at this stage, and the application of `terminal_velocity` remains unaffected.

I have tested this change locally and it appears to work as intended. Thank you for your time and for maintaining this project!