### PR TITLE
:hammer: fix(utils): use specific tags to find polymorphed player

### DIFF
--- a/files/scripts/lib/utils/player.lua
+++ b/files/scripts/lib/utils/player.lua
@@ -41,53 +41,20 @@ function GetPlayerMaxHealth()
 end
 
 function FindPolymorphedPlayer()
-  local nearby_polymorph = EntityGetWithTag("polymorphed") or {}
-  local polymorphed_players = {}
-  for _, entity in pairs(nearby_polymorph) do
-    local game_stats = EntityGetFirstComponent(entity, "GameStatsComponent")
-    if game_stats ~= nil then
-      if ComponentGetValue2(game_stats, "is_player") == true then
-        table.insert(polymorphed_players, entity)
-      end
-    end
+  local polymorphed_player = EntityGetWithTag("polymorphed_player")[1]
+  if polymorphed_player then
+    return polymorphed_player
   end
 
-  for _, player_id in ipairs(polymorphed_players) do
-    if
-      EntityGetFirstComponent(player_id, "AnimalAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "PhysicsAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "WormAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "AdvancedFishAIComponent") == nil
-    then
-      return player_id
-    end
-  end
-  return nil
+  return EntityGetWithTag("polymorphed_cessation")[1]
 end
 
 function FindSheepPlayer()
-  local nearby_polymorph = EntityGetWithTag("polymorphed") or {}
-  local polymorphed_players = {}
-  for _, entity in pairs(nearby_polymorph) do
-    local game_stats = EntityGetFirstComponent(entity, "GameStatsComponent")
-    if game_stats ~= nil then
-      if ComponentGetValue2(game_stats, "is_player") == true then
-        table.insert(polymorphed_players, entity)
-      end
-    end
-  end
-
-  for _, player_id in ipairs(polymorphed_players) do
-    if
-      EntityGetFirstComponent(player_id, "AnimalAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "PhysicsAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "WormAIComponent") == nil
-      and EntityGetFirstComponent(player_id, "AdvancedFishAIComponent") == nil
-    then
-      local entity_name = EntityGetName(player_id)
-      if entity_name == "$animal_sheep_fly" or entity_name == "$animal_sheep_bat" or entity_name == "$animal_sheep" then
-        return player_id
-      end
+  local polymorphed_player = EntityGetWithTag("polymorphed_player")[1]
+  if polymorphed_player then
+    local entity_name = EntityGetName(polymorphed_player)
+    if entity_name == "$animal_sheep_fly" or entity_name == "$animal_sheep_bat" or entity_name == "$animal_sheep" then
+      return polymorphed_player
     end
   end
   return nil


### PR DESCRIPTION
This PR refactors `FindPolymorphedPlayer()` and `FindSheepPlayer()` in `files/scripts/lib/utils/player.lua` to use a more direct and reliable detection method.

### The Problem

The current implementation uses a multi-step filtering pattern: it fetches entities with the `polymorphed` tag, checks for a `GameStatsComponent` with the `is_player` field set to true, and then further filters out any entity that has an enabled AI-related component (`AnimalAIComponent`, `PhysicsAIComponent`, etc.).

This logic can fail to identify the player when they are polymorphed into certain entities where the AI components remain enabled, such as those defined in `data/entities/animals/fish.xml` and `data/entities/animals/mimic_potion.xml`. Since `FindPolymorphedPlayer()` can be called via `GetPlayerEntity()` (used in A10/A17 logic), this can lead to incorrect behavior.

### The Fix

This PR updates the functions to use the more specific tags `polymorphed_player` and `polymorphed_cessation`. These tags are exclusively used on the player entity during polymorph, making the detection both simpler and more robust.

This approach aligns with the logic found in the vanilla game's `data/scripts/magic/null_room/check.lua` file, within the `nullroom_remove_all_perks()` function.

### Note on Intent

My assumption is that the primary goal of these functions is to reliably find the player entity while it is polymorphed. If the original filtering logic was deliberately intended to exclude certain AI-driven forms, please let me know.

### Other Observations

While reviewing this file, I noticed that several other functions have potential issues. Some are missing defensive guards, while others may use legacy APIs (like `ComponentGetValue`).

As these functions appear to be currently unused within the mod, I have not included fixes for them in this PR to keep its scope focused on the primary refactoring task.