### PR TITLE
:hammer: refactor(a16): rewrite biome modifier logic

### DIFF
--- a/files/scripts/appends/biome_modifiers.lua
+++ b/files/scripts/appends/biome_modifiers.lua
@@ -1,4 +1,54 @@
+local get_modifier_mappings_origin = get_modifier_mappings
+
+local function pick_random_biome_modifier_for_biomes(rnd, biome_modifiers, target_biomes)
+  local biome_modifiers_left = {}
+  for _, modifier in ipairs(biome_modifiers) do
+    for _, biome_name in ipairs(target_biomes) do
+      -- selene: allow(undefined_variable)
+      if biome_modifier_applies_to_biome(modifier, biome_name) == true then
+        table.insert(biome_modifiers_left, modifier)
+        break
+      end
+    end
+  end
+  -- selene: allow(undefined_variable)
+  return pick_random_from_table_weighted(rnd, biome_modifiers_left)
+end
+
 -- selene: allow(unused_variable)
-function has_modifiers(biome_name, ctx)
-  return true
+function get_modifier_mappings()
+  local result = get_modifier_mappings_origin()
+
+  -- selene: allow(undefined_variable, unscoped_variables)
+  rnd = random_create(347893, 90734)
+
+  -- selene: allow(undefined_variable)
+  for _, biome_names in ipairs(biomes) do
+    while true do
+      local target_biomes = {}
+      for _, biome_name in ipairs(biome_names) do
+        if result[biome_name] == nil then
+          table.insert(target_biomes, biome_name)
+        end
+      end
+      if #target_biomes == 0 then
+        break
+      end
+
+      -- selene: allow(undefined_variable)
+      local modifier = pick_random_biome_modifier_for_biomes(rnd, biome_modifiers, target_biomes)
+      if modifier == nil then
+        break
+      end
+
+      for _, biome_name in ipairs(target_biomes) do
+        -- selene: allow(undefined_variable)
+        if biome_modifier_applies_to_biome(modifier, biome_name) then
+          result[biome_name] = modifier
+        end
+      end
+    end
+  end
+
+  return result
 end

--- a/files/scripts/ascension_manager.lua
+++ b/files/scripts/ascension_manager.lua
@@ -210,6 +210,14 @@ function AscensionManager:on_world_initialized()
   end
 end
 
+function AscensionManager:on_biome_config_loaded()
+  for _, ascension in ipairs(self.active_ascensions) do
+    if ascension.on_biome_config_loaded then
+      ascension:on_biome_config_loaded()
+    end
+  end
+end
+
 function AscensionManager:on_enemy_spawn(payload)
   for _, ascension in ipairs(self.active_ascensions) do
     if ascension.on_enemy_spawn then

--- a/files/scripts/ascensions/a16.lua
+++ b/files/scripts/ascensions/a16.lua
@@ -18,4 +18,9 @@ function ascension:on_activate()
   ModLuaFileAppend("data/scripts/biome_modifiers.lua", "mods/kaleva_koetus/files/scripts/appends/biome_modifiers.lua")
 end
 
+function ascension:on_biome_config_loaded()
+  local init_biome_modifiers = dofile_once("data/scripts/biome_modifiers.lua")
+  init_biome_modifiers()
+end
+
 return ascension

--- a/files/scripts/ascensions/ascension_subscriber.lua
+++ b/files/scripts/ascensions/ascension_subscriber.lua
@@ -41,6 +41,8 @@ function ascension:on_mod_post_init() end
 -- Optional
 function ascension:on_world_initialized() end
 -- Optional
+function ascension:on_biome_config_loaded() end
+-- Optional
 function ascension:on_enemy_spawn(_enemy) end
 -- Optional
 function ascension:on_potion_generated(_potion) end

--- a/init.lua
+++ b/init.lua
@@ -59,6 +59,10 @@ function OnWorldInitialized()
   end
 end
 
+function OnBiomeConfigLoaded()
+  ascensionManager:on_biome_config_loaded()
+end
+
 function OnPlayerSpawned(player_entity_id) -- This runs when player entity has been created
   ascensionManager:on_player_spawn(player_entity_id)
 end


### PR DESCRIPTION
This PR overhauls the implementation for how Ascension 16 applies biome modifiers, replacing the previous method with a more robust, event-driven system supported by an extended callback.

### The Problem

The original implementation in `ascension:on_activate()` used `ModLuaFileAppend()` on `data/scripts/biome_modifiers.lua`. This approach had at least two significant issues:

**1. Execution Timing and State Desynchronization**

The vanilla `data/scripts/init.lua` executes very early in the game's startup sequence, *before* any mod's `init.lua`. This means the content of functions like `init_biome_modifiers()` is defined and locked into memory at this early stage. Although the function itself is only *called* later during the `OnBiomeConfigLoaded()` callback, the version that runs is the original, un-appended one.

Consequently, any `ModLuaFileAppend` performed later (e.g., in `OnModInit()` or the mod's `init.lua` body) is too late to affect the `init_biome_modifiers()` call made by the vanilla script. This creates a state desynchronization: the initial modifier setup is based on the un-appended file, while later-loading biome scripts see the appended version. This leads to partially or incorrectly applied effects.

**2. Flawed Modifier Assignment Logic**

The appended script's logic, which forced `has_modifiers()` to return `true`, only functioned as a prerequisite to allow the selection of a single modifier for a given biome group. The subsequent function, `pick_random_from_table_weighted()`, then selects one modifier from the entire global list, **without** any contextual guarantee of its suitability for the specific biomes in the current group. The final step is an individual applicability check for each biome using `biome_modifier_applies_to_biome()`. Consequently, it was likely that the randomly chosen global modifier would be inapplicable to one or more of the biomes within the group, resulting in an incomplete application that left some biomes unmodified. This contradicts the intended "always-on" effect.

### The Solution

This PR addresses both issues with a two-pronged approach:

**1. A New Callback for Correct Timing**

To solve the timing problem, the mod's callback system has been extended to recognize and dispatch the engine's `OnBiomeConfigLoaded()` event to all active ascensions.

A16 now leverages this new `on_biome_config_loaded()` callback to re-execute `init_biome_modifiers()` from the appended `biome_modifiers.lua`. This is done immediately after the vanilla execution in the same game state, which is the best practice. It ensures the execution happens at a point where engine-level data like the world seed is guaranteed to be initialized, as signaled by the preceding `OnMagicNumbersAndWorldSeedInitialized()` callback, making RNG-dependent API calls safe. This second execution is designed to be a safe, idempotent supplement to the vanilla call, ensuring a consistent state for all subsequent biome script executions.

**2. A Smarter Modifier Mapping Algorithm**

To solve the logic flaw, the appended script now hooks the `get_modifier_mappings()` function to implement a more intelligent assignment algorithm:

*   It first calls the original `get_modifier_mappings()` function and **respects its results**. This is crucial for preventing conflicts. The `init_biome_modifiers()` function, while having side effects, is subtly idempotent *as long as the modifier mapping remains the same*. The potential conflict arises because biome modifiers alter biome properties via API calls, and different modifiers may alter different sets of properties. If a second, different modifier is applied to a biome that already has one, its effects may not fully overwrite the first. This can result in an unintended **superposition of properties** from both modifiers, leading to unpredictable conflicts. By not altering already-assigned modifiers, the subsequent, modified `init_biome_modifiers()` call performs a safe, idempotent operation on those biomes. The new mapping logic is also designed to be deterministic and idempotent itself, minimizing the risk of future conflicts.

*   For any biome groups left without a modifier, it iteratively performs the following steps:
    1.  Filters the global modifier list to only include those applicable to at least one of the remaining biomes.
    2.  Picks a random modifier from this valid subset.
    3.  Applies it to all compatible biomes in the group.
    4.  Repeats until all biomes are covered or no applicable modifiers are left.

This revised approach is therefore more robust and directly addresses the original implementation's flaws. Local testing confirms that this new logic achieves both correct application and full modifier coverage as intended for A16. Furthermore, the added callback dispatch logic closely follows the established pattern for other event handlers already present in the mod. This architectural consistency ensures it is unlikely to introduce unintended side effects.