### PR TITLE
:hammer: fix(a11,a13): refactor enemy duplication and unify buff logic

### DIFF
--- a/files/scripts/appends/director_helpers.lua
+++ b/files/scripts/appends/director_helpers.lua
@@ -1,0 +1,48 @@
+local DuplicateUtils = dofile_once("mods/kaleva_koetus/files/scripts/ascensions/a11_entity_duplicate_utils.lua")
+
+local EntityLoadCameraBound_origin = EntityLoadCameraBound
+
+local function has_enemy_tag(tags)
+  local padded_tags = "," .. tags .. ","
+
+  if string.find(padded_tags, ",%s*enemy%s*,") then
+    return true
+  end
+
+  return false
+end
+
+local function file_not_boss_enemy(elem)
+  local tags = elem:get("tags")
+  if tags == nil then
+    return false
+  end
+
+  if has_enemy_tag(tags) == false then
+    return false
+  end
+
+  if DuplicateUtils.has_boss_tag(tags) == true then
+    return false
+  end
+
+  return true
+end
+
+-- selene: allow(unused_variable)
+function EntityLoadCameraBound(filename, pos_x, pos_y)
+  local duplicated_filename = DuplicateUtils.get_duplicated_filename(filename, file_not_boss_enemy)
+  if duplicated_filename == "" then
+    EntityLoadCameraBound_origin(filename, pos_x, pos_y)
+    return
+  end
+
+  EntityLoadCameraBound_origin(duplicated_filename, pos_x, pos_y)
+
+  local how_many = DuplicateUtils.get_extra_count(pos_x, pos_y)
+  for _ = 1, how_many, 1 do
+    local offset_x = Random(-16, 16)
+    local offset_y = Random(-16, 0)
+    EntityLoadCameraBound_origin(duplicated_filename, pos_x + offset_x, pos_y + offset_y)
+  end
+end

--- a/files/scripts/ascension_manager.lua
+++ b/files/scripts/ascension_manager.lua
@@ -218,6 +218,14 @@ function AscensionManager:on_enemy_spawn(payload)
   end
 end
 
+function AscensionManager:on_enemy_post_spawn(payload)
+  for _, ascension in ipairs(self.active_ascensions) do
+    if ascension.on_enemy_post_spawn then
+      ascension:on_enemy_post_spawn(payload)
+    end
+  end
+end
+
 function AscensionManager:on_shop_card_spawn(event_args)
   for _, ascension in ipairs(self.active_ascensions) do
     if ascension.on_shop_card_spawn then

--- a/files/scripts/ascensions/a1.lua
+++ b/files/scripts/ascensions/a1.lua
@@ -13,7 +13,7 @@ ascension.level = 1
 ascension.description = "$kaleva_koetus_description_a" .. ascension.level
 ascension.specification = "$kaleva_koetus_specification_a" .. ascension.level
 ascension.hp_multiplier = 1.5
-ascension.tag_name = AscensionTags.A1 .. EventTypes.ENEMY_SPAWN
+ascension.tag_name = AscensionTags.A1 .. EventTypes.ENEMY_POST_SPAWN
 
 function ascension:on_activate()
   -- log:info("Enemy HP increase active (x%d)", self.hp_multiplier)
@@ -25,7 +25,7 @@ function ascension:on_activate()
   )
 end
 
-function ascension:on_enemy_spawn(payload)
+function ascension:on_enemy_post_spawn(payload)
   local enemy_entity = tonumber(payload[1])
   if not enemy_entity then
     return

--- a/files/scripts/ascensions/a11.lua
+++ b/files/scripts/ascensions/a11.lua
@@ -1,68 +1,40 @@
 -- local Logger = dofile_once("mods/kaleva_koetus/files/scripts/lib/logger.lua")
 local AscensionBase = dofile_once("mods/kaleva_koetus/files/scripts/ascensions/ascension_subscriber.lua")
-local EventDefs = dofile_once("mods/kaleva_koetus/files/scripts/event_hub/event_types.lua")
-
-local AscensionTags = EventDefs.Tags
-local EventTypes = EventDefs.Types
+local DuplicateUtils = dofile_once("mods/kaleva_koetus/files/scripts/ascensions/a11_entity_duplicate_utils.lua")
 
 local ascension = setmetatable({}, { __index = AscensionBase })
 
 -- local log = Logger:new("a11.lua")
 
-local SPAWN_CHANCE_1 = 0.25
-local SPAWN_CHANCE_2 = 0.10
-local SPAWN_CHANCE_3 = 0.05
-
 ascension.level = 11
 ascension.description = "$kaleva_koetus_description_a" .. ascension.level
 ascension.specification = "$kaleva_koetus_specification_a" .. ascension.level
-ascension.tag_name = AscensionTags.A11 .. EventTypes.ENEMY_SPAWN
+ascension.tag_name = DuplicateUtils.tag_name
 
-local function is_boss_entity(entity_id)
-  if not entity_id or entity_id == 0 then
-    return false
-  end
-
+local function enemy_not_boss(entity_id)
   local tags = EntityGetTags(entity_id)
-  if not tags then
+  if tags == nil then
     return false
   end
 
-  for tag in string.gmatch(tags, "[^,]+") do
-    if tag == "boss" or string.find(tag, "boss_", 1, true) then
-      return true
-    end
+  if DuplicateUtils.has_boss_tag(tags) then
+    return false
   end
 
-  return false
-end
-
-local function duplicate_enemy(enemy_entity_id, x, y, how_many)
-  local entity_filename = EntityGetFilename(enemy_entity_id)
-  if not entity_filename or entity_filename == "" then
-    return
-  end
-
-  SetRandomSeed(x, y)
-  for _ = 1, how_many, 1 do
-    local offset_x = Random(-16, 16)
-    local offset_y = Random(-16, 0)
-    local duplicate_id = EntityLoad(entity_filename, x + offset_x, y + offset_y)
-    if duplicate_id then
-      EntityAddTag(duplicate_id, ascension.tag_name)
-      -- log:verbose("Spawned extra enemy %d from %d", duplicate_id, enemy_entity_id)
-    end
-  end
+  return true
 end
 
 function ascension:on_activate()
   -- log:info("Increasing enemy spawns")
+  DuplicateUtils.build_duplicated_files_from_storage()
+  ModLuaFileAppend("data/scripts/director_helpers.lua", "mods/kaleva_koetus/files/scripts/appends/director_helpers.lua")
 end
 
 function ascension:on_enemy_spawn(payload)
   local enemy_entity_id = tonumber(payload[1])
   local x = tonumber(payload[2]) or 0
   local y = tonumber(payload[3]) or 0
+  local mark_as_processed = payload[4]
 
   if not enemy_entity_id or enemy_entity_id == 0 then
     return
@@ -72,24 +44,48 @@ function ascension:on_enemy_spawn(payload)
     return
   end
 
-  if is_boss_entity(enemy_entity_id) then
-    -- log:debug("Skipping boss entity %d for duplication", enemy_entity_id)
+  if enemy_not_boss(enemy_entity_id) == false then
     return
   end
 
-  local seed_x = math.floor(x)
-  local seed_y = math.floor(y + GameGetFrameNum())
-  SetRandomSeed(seed_x, seed_y)
-  local randf = Randomf()
-  if randf <= SPAWN_CHANCE_3 then
-    -- log:verbose("4 enemy")
-    duplicate_enemy(enemy_entity_id, x, y, 3)
-  elseif randf <= SPAWN_CHANCE_2 then
-    -- log:verbose("3 enemy")
-    duplicate_enemy(enemy_entity_id, x, y, 2)
-  elseif randf <= SPAWN_CHANCE_1 then
-    -- log:verbose("2 enemy")
-    duplicate_enemy(enemy_entity_id, x, y, 1)
+  if EntityHasTag(enemy_entity_id, "polymorphed") then
+    return
+  end
+
+  local entity_filename = EntityGetFilename(enemy_entity_id)
+  if entity_filename == "" then
+    return
+  end
+  if entity_filename == "data/entities/animals/apparition/playerghost.xml" then
+    local children = EntityGetAllChildren(enemy_entity_id)
+    if children ~= nil then
+      for _, child_entity_id in ipairs(children) do
+        if EntityGetName(child_entity_id) == "inventory_quick" then
+          EntityAddTag(enemy_entity_id, ascension.tag_name)
+          local how_many = DuplicateUtils.get_extra_count(x, y)
+          for _ = 1, how_many, 1 do
+            local offset_x = Random(-16, 16)
+            local offset_y = Random(-16, 0)
+            local _, apparition_entity_id = SpawnApparition(x + offset_x, y + offset_y, 0, true)
+            EntityAddTag(apparition_entity_id, ascension.tag_name)
+          end
+          return
+        end
+      end
+    end
+  end
+
+  local duplicated_filename = DuplicateUtils.get_duplicated_filename(entity_filename)
+
+  mark_as_processed(enemy_entity_id)
+  EntityKill(enemy_entity_id)
+  local _ = EntityLoad(duplicated_filename, x, y)
+
+  local how_many = DuplicateUtils.get_extra_count(x, y)
+  for _ = 1, how_many, 1 do
+    local offset_x = Random(-16, 16)
+    local offset_y = Random(-16, 0)
+    _ = EntityLoad(duplicated_filename, x + offset_x, y + offset_y)
   end
 end
 

--- a/files/scripts/ascensions/a11_entity_duplicate_utils.lua
+++ b/files/scripts/ascensions/a11_entity_duplicate_utils.lua
@@ -1,0 +1,131 @@
+local json = dofile_once("mods/kaleva_koetus/files/scripts/lib/jsonlua/json.lua")
+local nxml = dofile_once("mods/kaleva_koetus/files/scripts/lib/luanxml/nxml.lua")
+local EventDefs = dofile_once("mods/kaleva_koetus/files/scripts/event_hub/event_types.lua")
+
+local DuplicateUtils = {}
+
+local SPAWN_CHANCE_1 = 0.25
+local SPAWN_CHANCE_2 = 0.10
+local SPAWN_CHANCE_3 = 0.05
+
+local AscensionTags = EventDefs.Tags
+local EventTypes = EventDefs.Types
+DuplicateUtils.tag_name = AscensionTags.A11 .. EventTypes.ENEMY_SPAWN
+
+function DuplicateUtils.has_boss_tag(tags)
+  local padded_tags = "," .. tags .. ","
+
+  if string.find(padded_tags, ",%s*boss%s*,") then
+    return true
+  end
+
+  if string.find(padded_tags, ",%s*boss_[^,]%s*,") then
+    return true
+  end
+
+  return false
+end
+
+local XML_ENTITY_WRAPPER_WITH_NAME = [[<Entity tags="%s" name="%s">
+%s
+</Entity>
+]]
+local XML_ENTITY_WRAPPER = [[<Entity tags="%s">
+%s
+</Entity>
+]]
+local XML_BASE_WRAPPER_WITH_CBC = [[  <Base file="%s" include_children="1">
+    <CameraBoundComponent
+      max_count="%d">
+    </CameraBoundComponent>
+  </Base>]]
+local XML_BASE_WRAPPER = [[  <Base file="%s" include_children="1" />]]
+local function get_duplicated_file_content(filename, should_duplicate)
+  local elem = nxml.parse_file(filename)
+  elem:expand_base()
+  if should_duplicate ~= nil and should_duplicate(elem) == false then
+    return nil
+  else
+    local base_elem
+    local camera_bound_component = elem:first_of("CameraBoundComponent")
+    if camera_bound_component ~= nil then
+      local max_count = camera_bound_component:get("max_count")
+      local max_count_value = tonumber(max_count) or 10
+      base_elem = string.format(XML_BASE_WRAPPER_WITH_CBC, filename, max_count_value * 4)
+    else
+      base_elem = string.format(XML_BASE_WRAPPER, filename)
+    end
+    local entity_name = elem:get("name")
+    if entity_name ~= nil then
+      return string.format(XML_ENTITY_WRAPPER_WITH_NAME, DuplicateUtils.tag_name, entity_name, base_elem)
+    else
+      return string.format(XML_ENTITY_WRAPPER, DuplicateUtils.tag_name, base_elem)
+    end
+  end
+end
+
+local duplicated_file_storage_key = "kaleva_koetus.a11_duplicated_files"
+local ModTextFileSetContent = ModTextFileSetContent
+
+local cached_filename = {}
+function DuplicateUtils.get_duplicated_filename(filename, should_duplicate)
+  if cached_filename[filename] == nil then
+    local duplicated_files_data = ModSettingGet(duplicated_file_storage_key)
+    local duplicated_files
+    if duplicated_files_data == nil then
+      duplicated_files = {}
+    else
+      duplicated_files = json.decode(duplicated_files_data)
+    end
+
+    for origin_filename, related_filename in pairs(duplicated_files) do
+      cached_filename[origin_filename] = related_filename
+    end
+
+    if cached_filename[filename] == nil then
+      local related_filename = "mods/kaleva_koetus/a11/" .. filename
+      local file_content = get_duplicated_file_content(filename, should_duplicate)
+      if file_content == nil then
+        cached_filename[filename] = ""
+      else
+        ModTextFileSetContent(related_filename, file_content)
+        cached_filename[filename] = related_filename
+
+        duplicated_files[filename] = related_filename
+        local json_content = json.encode(duplicated_files)
+        ModSettingSet(duplicated_file_storage_key, json_content)
+      end
+    end
+  end
+
+  return cached_filename[filename]
+end
+
+function DuplicateUtils.build_duplicated_files_from_storage()
+  if SessionNumbersGetValue("is_biome_map_initialized") == "0" then
+    local _ = ModSettingRemove(duplicated_file_storage_key)
+    return
+  end
+  local duplicated_files_data = ModSettingGet(duplicated_file_storage_key)
+  local duplicated_files = json.decode(duplicated_files_data)
+  for origin_filename, related_filename in pairs(duplicated_files) do
+    local file_content = get_duplicated_file_content(origin_filename)
+    ModTextFileSetContent(related_filename, file_content)
+  end
+end
+
+function DuplicateUtils.get_extra_count(x, y)
+  SetRandomSeed(x, y + GameGetFrameNum())
+  local randf = Randomf()
+  if randf <= SPAWN_CHANCE_3 then
+    return 3
+  elseif randf <= SPAWN_CHANCE_2 then
+    return 2
+  elseif randf <= SPAWN_CHANCE_1 then
+    return 1
+  else
+    return 0
+  end
+end
+
+return DuplicateUtils

--- a/files/scripts/ascensions/a13.lua
+++ b/files/scripts/ascensions/a13.lua
@@ -14,7 +14,7 @@ local UPGRADE_CHANCE = 0.20
 ascension.level = 13
 ascension.description = "$kaleva_koetus_description_a" .. ascension.level
 ascension.specification = "$kaleva_koetus_specification_a" .. ascension.level
-ascension.tag_name = AscensionTags.A13 .. EventTypes.ENEMY_SPAWN
+ascension.tag_name = AscensionTags.A13 .. EventTypes.ENEMY_POST_SPAWN
 
 local function random_unique_integers(min, max, count)
   local numbers = {}
@@ -140,8 +140,8 @@ function ascension:on_activate()
   -- log:info("Elite enemy spawns")
 end
 
-function ascension:on_enemy_spawn(payload)
-  -- log:verbose("on_enemy_spawn")
+function ascension:on_enemy_post_spawn(payload)
+  -- log:verbose("on_enemy_post_spawn")
 
   local enemy_entity_id = tonumber(payload[1])
   local x = tonumber(payload[2]) or 0

--- a/files/scripts/ascensions/a13_cleanup_orphan_entity.lua
+++ b/files/scripts/ascensions/a13_cleanup_orphan_entity.lua
@@ -1,0 +1,6 @@
+local entity_id = GetUpdatedEntityID()
+
+local parent_entity_id = EntityGetParent(entity_id)
+if parent_entity_id == 0 then
+  EntityKill(entity_id)
+end

--- a/files/scripts/ascensions/a13_elite_skills.lua
+++ b/files/scripts/ascensions/a13_elite_skills.lua
@@ -29,10 +29,6 @@ function a13_elite_skills:add_extra_projectile(enemy_entity_id)
   local projectile_min = ComponentGetValue2(component_id, "attack_ranged_entity_count_min")
   local projectile_max = ComponentGetValue2(component_id, "attack_ranged_entity_count_max")
 
-  if not projectile_min or not projectile_max then
-    return
-  end
-
   local multiplier = a13_elite_skills.projectile_multiplier
   ComponentSetValue2(component_id, "attack_ranged_entity_count_min", projectile_min * multiplier)
   ComponentSetValue2(component_id, "attack_ranged_entity_count_max", projectile_max * multiplier)
@@ -89,11 +85,10 @@ function a13_elite_skills:increase_hp(enemy_entity_id)
     return
   end
 
+  local max_hp = ComponentGetValue2(component_id, "max_hp")
   local current_hp = ComponentGetValue2(component_id, "hp")
-  if not current_hp then
-    return
-  end
 
+  ComponentSetValue2(component_id, "max_hp", max_hp * ELITE_HP_MULTIPLIER)
   ComponentSetValue2(component_id, "hp", current_hp * ELITE_HP_MULTIPLIER)
 end
 
@@ -102,6 +97,10 @@ function a13_elite_skills:increase_character_speed(enemy_entity_id)
   local game_effect_comp, game_effect_entity = GetGameEffectLoadTo(enemy_entity_id, "MOVEMENT_FASTER_2X", false)
   if (game_effect_comp ~= nil) and (game_effect_entity ~= nil) then
     ComponentSetValue(game_effect_comp, "frames", "-1")
+    local _ = EntityAddComponent2(game_effect_entity, "LuaComponent", {
+      script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a13_cleanup_orphan_entity.lua",
+      remove_after_executed = true,
+    })
   end
 end
 
@@ -111,12 +110,17 @@ function a13_elite_skills:increase_melee_damage(enemy_entity_id)
   if not component_id then
     return
   end
-  local range_attack = ComponentGetValue2(component_id, "attack_ranged_entity_file")
-  if range_attack == "" or range_attack == nil then
+  local melee_enabled = ComponentGetValue2(component_id, "attack_melee_enabled")
+  if melee_enabled == true then
     local melee_damage_min = ComponentGetValue2(component_id, "attack_melee_damage_min")
     local melee_damage_max = ComponentGetValue2(component_id, "attack_melee_damage_max")
     ComponentSetValue2(component_id, "attack_melee_damage_min", melee_damage_min * DAMAGE_MELEE_MULTIPLIER)
     ComponentSetValue2(component_id, "attack_melee_damage_max", melee_damage_max * DAMAGE_MELEE_MULTIPLIER)
+  end
+  local dash_enabled = ComponentGetValue2(component_id, "dash_enabled")
+  if dash_enabled == true then
+    local dash_damage = ComponentGetValue2(component_id, "attack_dash_damage")
+    ComponentSetValue2(component_id, "attack_dash_damage", dash_damage * DAMAGE_MELEE_MULTIPLIER)
   end
 end
 
@@ -126,13 +130,22 @@ function a13_elite_skills:add_shield(enemy_entity_id)
   local x, y = EntityGetTransform(enemy_entity_id)
   local child_id = EntityLoad("data/entities/misc/perks/shield.xml", x, y)
   EntityAddChild(enemy_entity_id, child_id)
+  local _ = EntityAddComponent2(child_id, "LuaComponent", {
+    script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a13_cleanup_orphan_entity.lua",
+    remove_after_executed = true,
+  })
 end
 
 function a13_elite_skills:add_area_damage(enemy_entity_id)
   -- log:debug("add_area_damage")
 
-  local entity_id = EntityLoad("data/entities/misc/perks/contact_damage_enemy.xml")
-  EntityAddChild(enemy_entity_id, entity_id)
+  local x, y = EntityGetTransform(enemy_entity_id)
+  local child_id = EntityLoad("data/entities/misc/perks/contact_damage_enemy.xml", x, y)
+  EntityAddChild(enemy_entity_id, child_id)
+  local _ = EntityAddComponent2(child_id, "LuaComponent", {
+    script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a13_cleanup_orphan_entity.lua",
+    remove_after_executed = true,
+  })
 end
 
 function a13_elite_skills:use_wand(enemy_entity_id)

--- a/files/scripts/ascensions/a13_increase_damage_on_shot_append.lua
+++ b/files/scripts/ascensions/a13_increase_damage_on_shot_append.lua
@@ -8,6 +8,10 @@ local DAMAGE_PROJECTILE_MULTIPLIER = 2
 function shot(projectile_entity_id)
   -- log:debug("elite enemy shot")
   local projectile_component_id = EntityGetFirstComponent(projectile_entity_id, "ProjectileComponent")
+  if projectile_component_id ~= nil then
+    return
+  end
+
   local damage = ComponentGetValue2(projectile_component_id, "damage")
   ComponentSetValue2(projectile_component_id, "damage", damage * DAMAGE_PROJECTILE_MULTIPLIER)
 

--- a/files/scripts/ascensions/a13_increase_explosion_on_shot_append.lua
+++ b/files/scripts/ascensions/a13_increase_explosion_on_shot_append.lua
@@ -8,6 +8,10 @@ local ELITE_EXPLOSION_STAINS_RADIUS = 1.25
 function shot(projectile_entity_id)
   -- log:debug("elite enemy shot")
   local projectile_component_id = EntityGetFirstComponent(projectile_entity_id, "ProjectileComponent")
+  if projectile_component_id ~= nil then
+    return
+  end
+
   local explosion_radius = ComponentObjectGetValue2(projectile_component_id, "config_explosion", "explosion_radius")
   local stains_radius = ComponentObjectGetValue2(projectile_component_id, "config_explosion", "stains_radius")
   ComponentObjectSetValue2(

--- a/files/scripts/ascensions/a13_increase_speed_on_shot_append.lua
+++ b/files/scripts/ascensions/a13_increase_speed_on_shot_append.lua
@@ -7,7 +7,7 @@ local ELITE_PROJECTILE_SPEED = 1.5
 function shot(projectile_entity_id)
   -- log:debug("elite enemy shot")
   local velocity_component_id = EntityGetFirstComponent(projectile_entity_id, "VelocityComponent")
-  if not velocity_component_id then
+  if velocity_component_id ~= nil then
     return
   end
 

--- a/files/scripts/ascensions/a14.lua
+++ b/files/scripts/ascensions/a14.lua
@@ -14,7 +14,7 @@ local GOLD_LIFETIME_MULTIPLIER = 0.25
 ascension.level = 14
 ascension.description = "$kaleva_koetus_description_a" .. ascension.level
 ascension.specification = "$kaleva_koetus_specification_a" .. ascension.level
-ascension.tag_name = AscensionTags.A14 .. EventTypes.ENEMY_SPAWN
+ascension.tag_name = AscensionTags.A14 .. EventTypes.GOLD_SPAWN
 
 function ascension:on_activate()
   -- log:info("Gold lifetime will be half")

--- a/files/scripts/ascensions/ascension_subscriber.lua
+++ b/files/scripts/ascensions/ascension_subscriber.lua
@@ -43,6 +43,8 @@ function ascension:on_world_initialized() end
 -- Optional
 function ascension:on_enemy_spawn(_enemy) end
 -- Optional
+function ascension:on_enemy_post_spawn(_enemy) end
+-- Optional
 function ascension:on_potion_generated(_potion) end
 -- Optional
 function ascension:on_book_generated(_book) end

--- a/files/scripts/enemy_detector.lua
+++ b/files/scripts/enemy_detector.lua
@@ -69,6 +69,35 @@ function EnemyDetector:init(called_from)
   -- log:debug("initialized")
 end
 
+function EnemyDetector:get_processed_marker()
+  return function(entity_id)
+    EntityAddTag(entity_id, self.tag_name)
+  end
+end
+
+function EnemyDetector:check_unprocessed_enemies()
+  local all_enemies = EntityGetWithTag("enemy")
+  if #all_enemies == 0 then
+    return {}
+  end
+
+  local unprocessed_enemies = {}
+  for _, entity_id in ipairs(all_enemies) do
+    if not EntityHasTag(entity_id, self.tag_name) then
+      local x, y = EntityGetTransform(entity_id)
+      if is_active(entity_id) then
+        unprocessed_enemies[#unprocessed_enemies + 1] = {
+          id = entity_id,
+          x = x,
+          y = y,
+        }
+      end
+    end
+  end
+
+  return unprocessed_enemies
+end
+
 function EnemyDetector:get_unprocessed_enemies()
   if self.latest_entity_id == EntitiesGetMaxID() then
     return {}

--- a/files/scripts/event_hub/event_types.lua
+++ b/files/scripts/event_hub/event_types.lua
@@ -4,6 +4,7 @@
 local EventTypes = {
   -- Currently implemented events
   ENEMY_SPAWN = "enemy_spawn", -- enemy entity spawned
+  ENEMY_POST_SPAWN = "enemy_post_spawn", -- called after the main enemy spawn event
   SHOP_CARD_SPAWN = "shop_card_spawn", -- spell card spawned in temple shop
   SHOP_WAND_SPAWN = "shop_wand_spawn", -- wand spawned in temple shop
   PLAYER_SPAWN = "player_spawn",
@@ -23,6 +24,12 @@ local EventTypes = {
 -- Note: source and event_type are handled by EventBroker
 local EventArgs = {
   [EventTypes.ENEMY_SPAWN] = {
+    { name = "entity_id", type = "number" },
+    { name = "x", type = "number" },
+    { name = "y", type = "number" },
+    { name = "mark_as_processed", type = "function" },
+  },
+  [EventTypes.ENEMY_POST_SPAWN] = {
     { name = "entity_id", type = "number" },
     { name = "x", type = "number" },
     { name = "y", type = "number" },

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ local EnemyDetector = dofile_once("mods/kaleva_koetus/files/scripts/enemy_detect
 local SpellDetector = dofile_once("mods/kaleva_koetus/files/scripts/spell_detector.lua")
 local ImageEditor = dofile_once("mods/kaleva_koetus/files/scripts/image_editor.lua")
 
+local mark_enemy_as_processed
 -- log:info("Kaleva Koetus mod loading...")
 
 function OnModPreInit()
@@ -42,6 +43,8 @@ function OnWorldInitialized()
   EnemyDetector:init("from_init")
   SpellDetector:init("from_init")
 
+  mark_enemy_as_processed = EnemyDetector:get_processed_marker()
+
   -- 存在するイベントをすべて登録する
   for _, event_type in pairs(EventTypes) do
     eventBroker:subscribe_event(event_type, ascensionManager)
@@ -64,18 +67,19 @@ function OnPlayerSpawned(player_entity_id) -- This runs when player entity has b
 end
 
 function OnWorldPreUpdate()
-  local unprocessed_enemies = EnemyDetector:get_unprocessed_enemies()
-  if #unprocessed_enemies > 0 then
-    for _, enemy_data in ipairs(unprocessed_enemies) do
-      eventBroker:direct_dispatch(EventTypes.ENEMY_SPAWN, enemy_data.id, enemy_data.x, enemy_data.y)
-    end
+  local unprocessed_enemies = EnemyDetector:check_unprocessed_enemies()
+  for _, enemy_data in ipairs(unprocessed_enemies) do
+    eventBroker:direct_dispatch(EventTypes.ENEMY_SPAWN, enemy_data.id, enemy_data.x, enemy_data.y, mark_enemy_as_processed)
+  end
+
+  unprocessed_enemies = EnemyDetector:get_unprocessed_enemies()
+  for _, enemy_data in ipairs(unprocessed_enemies) do
+    eventBroker:direct_dispatch(EventTypes.ENEMY_POST_SPAWN, enemy_data.id, enemy_data.x, enemy_data.y)
   end
 
   local unprocessed_spells = SpellDetector:get_unprocessed_spells()
-  if #unprocessed_spells > 0 then
-    for _, spell_data in ipairs(unprocessed_spells) do
-      eventBroker:publish_event_sync("init", EventTypes.SPELL_GENERATED, spell_data.id)
-    end
+  for _, spell_data in ipairs(unprocessed_spells) do
+    eventBroker:publish_event_sync("init", EventTypes.SPELL_GENERATED, spell_data.id)
   end
 
   eventBroker:flush_event_queue()


### PR DESCRIPTION
This PR primarily resolves two major issues: an unreliable enemy duplication mechanism in A11 due to entity reloading, and several bugs in A13's elite enemy logic, including missing nil checks and orphaned child entities.

### The Problem

**1. A11: Enemy Duplication Fails on Entity Reload**

The original A11 logic detected new enemies, loaded copies from their entity filenames, and applied `the tag used by A11` to both the original and the copies to prevent re-duplication.

However, this approach fails due to a critical engine mechanic: enemies with a `CameraBoundComponent` are not fully persisted when unloaded. The engine only saves their filename and position, discarding all other runtime information, including the crucial `the tag used by A11`.

This means that as soon as a tagged enemy is unloaded and reloaded by the engine, it loses its tag and becomes eligible for duplication again. This issue is frequently triggered because `CameraBoundComponent` also actively unloads entities when too many of the same type are present. A11's duplication logic actively contributes to hitting this limit, causing enemies to be re-duplicated repeatedly even within a single screen as the player moves back and forth. This deviates from the original intent of a one-time spawn increase.

**2. A13: Elite Enemy Logic Flaws**

Several issues were identified in the A13 elite enemy implementation:

*   **Missing Nil Checks**: The scripts `a13_increase_damage_on_shot_append.lua` and `a13_increase_explosion_on_shot_append.lua` did not perform a nil check on the value returned by `EntityGetFirstComponent`. When an enemy with a non-projectile "shot" (e.g., the necromancer's `polyorb.xml` projectile, which lacks a `ProjectileComponent`) fired, the `shot()` function would receive an entity ID without the expected component, leading to a Lua error on subsequent `Component*` API calls.
*   **Orphaned Child Entities**: When applying child entities (like shields, contact damage fields, or status effects via `GetGameEffectLoadTo`), an issue with the engine's ECS was observed. After a process similar to `EntityKill` executed on an entity, it can, within the same frame, still be found by APIs like `EntityGetWithTag`. However, any new child entity attached via `EntityAddChild` during this "dying" state is not correctly parented for cleanup. When the parent entity is finally removed by the ECS, the child is not, resulting in observable glitches like shields and damage fields left hanging in mid-air. The behavior of `CameraBoundComponent` is highly suspect in creating these timing conditions.

### The Solution

**1. A11: Virtual Entity Files for Persistent Duplication**

To solve the persistence problem, the implementation now writes crucial modifications directly to virtual XML files and uses these files to replace the original entities. (Note: The `ModTextFile*` APIs are used here to dynamically generate the entity files. Contrary to some API documentation, these functions remain available and functional within the biome-specific Lua contexts. While they are set to `nil` in the main mod `init.lua` context after `OnModPostInit`, saving a reference to them before this point allows them to be used later as expected.)

Specifically, a new XML file is dynamically generated for each unique enemy type. It uses `<Base file="..." include_children="1">` to inherit the original entity's components and children. The entity name, which is not inherited this way, is explicitly copied from the original file's `<Entity>` attributes to the new one. `The tag used by A11` is also added to the new file's `<Entity>` attributes, ensuring persistence. This new virtual file is then uniquely associated with the original.

The duplication process is now a two-part system:
1.  **`director_helpers.lua` is appended** to modify `EntityLoadCameraBound`. This file is chosen as a trick because all vanilla calls to this function are routed through it. The hooked function replaces the original filename with our virtual one, and also loads the additional duplicated copies.
2.  A11's logic, using the results from the **`EnemyDetector`**, handles enemies intended for duplication by removing the original entity via `EntityKill`, and then loading both a replacement and its additional copies using the associated virtual file.

This mapping of original-to-virtual files is persisted in `ModSettings` and cached in Lua. Persistence is required because saved games can load chunks and their entities before `OnWorldInitialized`, so the virtual files must be ready on demand.

**2. A13 & System: Coordinated Spawn Events and Bug Fixes**

To coordinate A11's new "kill-then-load" logic with A13's "modify-existing-entity" logic, the event system has been expanded:

*   The original `ENEMY_SPAWN` logic has been moved to a new `ENEMY_POST_SPAWN` event.
*   The new `ENEMY_SPAWN` event fires first, using `check_unprocessed_enemies` and providing a `mark_as_processed` function.
*   **A11 now runs on `ENEMY_SPAWN`**. It performs its replacement/duplication and calls `mark_as_processed` on the original, now-killed entity ID.
*   **A1 and A13 now run on `ENEMY_POST_SPAWN`**. This ensures they only operate on the final, living entities and ignore the now-irrelevant original entity ID, preventing conflicts.

For A13's specific bugs:
*   Nil checks for required components have been added to all `script_shot` files.
*   To fix the orphaned entity issue, a new `a13_cleanup_orphan_entity.lua` script is attached as a `LuaComponent` to all relevant child entities. This script runs on the next frame, checks if it has a parent, and kills itself if it is orphaned. This is now applied to the status effect from `increase_character_speed` and the child entities from `add_shield` and `add_area_damage`.