### PR TITLE
:hammer: fix(a15): stabilize RNG for spell modifications

### DIFF
--- a/files/scripts/ascensions/a15_random_utils.lua
+++ b/files/scripts/ascensions/a15_random_utils.lua
@@ -1,0 +1,72 @@
+-- selene: allow(undefined_variable)
+local bit = bit
+
+local RandomUtils = {}
+RandomUtils.UNCOMPLETED_MULTIPLIER = 0.3
+
+local MAGIC_MULTIPLIER = 0x45d9f3b
+local MASK_32BIT = 0xFFFFFFFF
+
+local function addr_seed_from_table(t)
+  local s = tostring(t or {})
+  local hex = s:match("0x(%x+)") or s:match("(%x+)$") or "0"
+  local n = tonumber(hex, 16) or 0
+  n = bit.bxor(n, bit.rshift(n, 16))
+  n = bit.band(n * MAGIC_MULTIPLIER, MASK_32BIT)
+  return n
+end
+
+local function mix_integer(n, mix_val)
+  n = bit.bxor(n, mix_val)
+  n = bit.band(n * MAGIC_MULTIPLIER, MASK_32BIT)
+  n = bit.bxor(n, bit.rshift(n, 16))
+  return n
+end
+
+local gun_action_seed_key = "kaleva_koetus.gun_action_seed"
+
+function RandomUtils.init_root_seed()
+  if SessionNumbersGetValue("is_biome_map_initialized") == "0" then
+    local gun_action_seed = addr_seed_from_table()
+    local year, month, day, hour, minute, second = GameGetDateAndTimeUTC()
+    gun_action_seed = mix_integer(gun_action_seed, year)
+    gun_action_seed = mix_integer(gun_action_seed, month)
+    gun_action_seed = mix_integer(gun_action_seed, day)
+    gun_action_seed = mix_integer(gun_action_seed, hour)
+    gun_action_seed = mix_integer(gun_action_seed, minute)
+    gun_action_seed = mix_integer(gun_action_seed, second)
+    ModSettingSet(gun_action_seed_key, gun_action_seed)
+  end
+end
+
+function RandomUtils.derive_seed(domain)
+  local derived_seed = ModSettingGet(gun_action_seed_key) or 0
+  for i = 1, #domain do
+    local char_code = string.byte(domain, i)
+    derived_seed = mix_integer(derived_seed, char_code)
+  end
+  return derived_seed
+end
+
+function RandomUtils.random_unique_integers(min, max, count)
+  min = min - 1
+  local total = max - min
+  local numbers = {}
+  for i = 1, total do
+    numbers[i] = i + min
+  end
+
+  for i = 1, count do
+    local j = math.random(i, total)
+    numbers[i], numbers[j] = numbers[j], numbers[i]
+  end
+
+  local result = {}
+  for i = 1, count do
+    result[i] = numbers[i]
+  end
+
+  return result
+end
+
+return RandomUtils


### PR DESCRIPTION
This PR improves the RNG seed persistence logic for A15. It also enhances the randomness of individual spell modifications by using derived seeds, ensuring results are both consistent where needed and varied where intended.

### The Problem

The original implementation used Lua's native RNG instead of Noita's, which allowed for random results to be determined before the engine's main seed was available and helped maintain stability across New Game+ runs. However, this approach had several key flaws:

1.  **Inconsistent Spell Selection Across Game Restarts**: In `a15.lua`, the `on_mod_post_init()` function used a non-persistent seed source (based on UTC time) to determine which spells should be modified. This caused the list of "broken" spells to change every time the game was launched.

2.  **Coupled and Stale Randomness for Modifications**: In `gun_actions.lua`, a single, persistent seed was used for *all* modified spells. This seed was never reset for a new game, and its shared usage meant that the random modifications (e.g., `has_cool_time`, `has_fire_rate_debuff`) were coupled across all affected spells, reducing variety.

### The Solution

The core of the solution is a new utility module, `a15_random_utils.lua`, which centralizes A15's random logic and introduces a deterministic seed derivation system.

1.  **A Stable, Per-Session Root Seed**: The new utility provides a helper function, `init_root_seed()`, which checks `SessionNumbersGetValue("is_biome_map_initialized") == "0"`. This ensures a new root seed is generated only once at the very beginning of a new run and is then persisted in `ModSettings`.

2.  **Deterministic Seed Derivation**: A new `derive_seed(domain)` method allows for the creation of unique, stable seeds derived from the root seed using a string domain (e.g., `"gun_actions"`, `"gun_action_123"`). The behavior of this system is idempotent and stable throughout a single game session.

3.  **Decoupled and Consistent Logic**:
    *   `a15.lua`'s `on_mod_post_init()` now only handles inverting the color of the target spell sprites.
    *   The appended `gun_actions.lua` uses the same seed derivation logic to get the exact same list of target spells.
    *   Crucially, before applying modifications to each individual spell via `a15_action()`, a **unique and stable derived seed** is now generated for that specific spell.

This ensures that the selection of which spells are modified is consistent for the entire run, while the specific debuffs applied to each spell are varied but also consistent for that specific spell.

I have confirmed through local testing that these changes produce consistent random results across multiple game loads and within different Lua contexts during a single run.