### PR TITLE
:hammer: fix(a4): prevent effect from being re-applied on game reboot

### DIFF
--- a/files/scripts/ascensions/a4.lua
+++ b/files/scripts/ascensions/a4.lua
@@ -19,7 +19,13 @@ function ascension:on_activate()
 end
 
 function ascension:on_player_spawn()
+  if GlobalsGetValue(ascension.tag_name, "0") == "1" then
+    return
+  end
+
   GlobalsSetValue("STEVARI_DEATHS", tostring(2))
+
+  GlobalsSetValue(ascension.tag_name, "1")
 end
 
 function ascension:on_necromancer_spawn(payload)
@@ -33,15 +39,8 @@ function ascension:on_necromancer_spawn(payload)
 
   -- log:debug("Summoning guardians at %d,%d", x, y)
 
-  local thunder_skull_id = EntityLoad("data/entities/animals/thunderskull.xml", x - 20, y)
-  if thunder_skull_id then
-    EntityAddTag(thunder_skull_id, ascension.tag_name)
-  end
-
-  local ice_skull_id = EntityLoad("data/entities/animals/iceskull.xml", x + 20, y)
-  if ice_skull_id then
-    EntityAddTag(ice_skull_id, ascension.tag_name)
-  end
+  local _ = EntityLoad("data/entities/animals/thunderskull.xml", x - 20, y)
+  _ = EntityLoad("data/entities/animals/iceskull.xml", x + 20, y)
 end
 
 return ascension


### PR DESCRIPTION
This is a small fix to ensure the effect of Ascension 4 is applied only once per run, preventing an exploit related to game reloads.

 ### The Problem

In the original implementation, A4's effect in `on_player_spawn` would set the `STEVARI_DEATHS` global to `"2"` every time the game was loaded. This created an exploit: a player could kill a `necromancer` to increment the value to `"3"` (angering the gods), then simply reload the game to reset the value back to `"2"`, allowing them to circumvent the intended challenge of A4, which is to face a more powerful `necromancer_super` once the gods are angered.

### The Solution

Following the pattern already established for A9, this fix introduces a guard flag to ensure the effect is applied only once.

A flag is now set in `Globals` after the `STEVARI_DEATHS` value is set for the first time. The `on_player_spawn` function now checks for this flag and will not re-apply the effect if the flag is present, solving the exploit.

**Additionally, some related cleanup was performed:**
While implementing this, I noticed that `on_necromancer_spawn` was adding a tag to the two summoned skulls. This tag was not being checked or utilized by any other logic, so the `EntityAddTag` calls have been removed. The tag's name (`ascension.tag_name`) has been repurposed as the key for the new `Globals` guard flag.