### PR TITLE
:hammer: fix(a11): Preserve gold drop behavior on enemy duplication

### DIFF
--- a/files/scripts/ascensions/a11.lua
+++ b/files/scripts/ascensions/a11.lua
@@ -24,6 +24,27 @@ local function enemy_not_boss(entity_id)
   return true
 end
 
+local function has_no_gold(entity_id)
+  if EntityGetFirstComponent(entity_id, "VariableStorageComponent", "no_gold_drop") ~= nil then
+    return true
+  end
+
+  local lua_components = EntityGetComponent(entity_id, "LuaComponent")
+  if lua_components ~= nil then
+    for _, lua_component in ipairs(lua_components) do
+      if ComponentGetValue2(lua_component, "script_death") == "data/scripts/items/drop_money.lua" then
+        return false
+      end
+    end
+  end
+
+  return true
+end
+
+local function add_no_gold(entity_id)
+  local _ = EntityAddComponent2(entity_id, "VariableStorageComponent", { _tags = "no_gold_drop" })
+end
+
 function ascension:on_activate()
   -- log:info("Increasing enemy spawns")
   DuplicateUtils.build_duplicated_files_from_storage()
@@ -56,6 +77,9 @@ function ascension:on_enemy_spawn(payload)
   if entity_filename == "" then
     return
   end
+
+  local should_no_gold = has_no_gold(enemy_entity_id)
+
   if entity_filename == "data/entities/animals/apparition/playerghost.xml" then
     local children = EntityGetAllChildren(enemy_entity_id)
     if children ~= nil then
@@ -68,6 +92,9 @@ function ascension:on_enemy_spawn(payload)
             local offset_y = Random(-16, 0)
             local _, apparition_entity_id = SpawnApparition(x + offset_x, y + offset_y, 0, true)
             EntityAddTag(apparition_entity_id, ascension.tag_name)
+            if should_no_gold == true then
+              add_no_gold(apparition_entity_id)
+            end
           end
           return
         end
@@ -79,13 +106,20 @@ function ascension:on_enemy_spawn(payload)
 
   mark_as_processed(enemy_entity_id)
   EntityKill(enemy_entity_id)
-  local _ = EntityLoad(duplicated_filename, x, y)
+  local new_entity_id = EntityLoad(duplicated_filename, x, y)
+  should_no_gold = should_no_gold and has_no_gold(new_entity_id) == false
+  if should_no_gold == true then
+    add_no_gold(new_entity_id)
+  end
 
   local how_many = DuplicateUtils.get_extra_count(x, y)
   for _ = 1, how_many, 1 do
     local offset_x = Random(-16, 16)
     local offset_y = Random(-16, 0)
-    _ = EntityLoad(duplicated_filename, x + offset_x, y + offset_y)
+    new_entity_id = EntityLoad(duplicated_filename, x + offset_x, y + offset_y)
+    if should_no_gold == true then
+      add_no_gold(new_entity_id)
+    end
   end
 end
 


### PR DESCRIPTION
### Description

This PR resolves #33 by introducing logic to preserve the "no_gold_drop" status of enemies processed by the A11 ascension. The previous implementation completely lacked checks for this property, causing some enemies that should not drop gold to do so after being replaced by their A11 counterparts.

### Implementation Details

A new check has been introduced to determine if an enemy should drop gold by inspecting two different mechanisms used in the vanilla game:

1.  **`VariableStorageComponent` Check**: It checks for the presence of a `VariableStorageComponent` with the `no_gold_drop` tag. This handles entities that are explicitly marked not to drop gold, such as the animal fungus from `data/entities/misc/fungus_projectile.xml`.

2.  **Death Script Check**: It now also inspects the entity's `LuaComponent`s to verify if the standard gold-dropping script, `data/scripts/items/drop_money.lua`, is assigned to the `script_death` field of any of these components. This correctly handles enemies like the spiders from `data/scripts/buildings/spidernest.lua`, whose base XML file includes a `script_death` for dropping money, but this component is altered by their spawner script upon creation.

This dual-check accurately determines the gold-dropping status from the initial enemy that triggers the `ON_ENEMY_SPAWN` event. This status is then propagated to the new replacement entities loaded by the A11 logic, ensuring the intended behavior is preserved.

---
Fixes #33