### PR TITLE
:sparkles: feat(a20): Remove victory room biome in NG0 runs

### DIFF
--- a/files/scripts/appends/biome_map.lua
+++ b/files/scripts/appends/biome_map.lua
@@ -1,0 +1,36 @@
+-- selene: allow(undefined_variable)
+local bit = bit
+
+local width, height = BiomeMapGetSize()
+local function replace_color(color_to_replace, new_biome_color, on_replace)
+  for y = 0, height - 1 do
+    for x = 0, width - 1 do
+      if bit.bxor(BiomeMapGetPixel(x, y), color_to_replace) == 0 then
+        if on_replace == nil or on_replace(x, y) then
+          BiomeMapSetPixel(x, y, new_biome_color)
+        end
+      end
+    end
+  end
+end
+
+local biome_boss_victoryroom = 0xffd7ee50
+local biome_lava = 0xffFF6A02
+local biome_solid_wall_temple = 0xff28A9B8
+
+local victoryroom_pixels = {}
+local function get_victoryroom(x, y)
+  table.insert(victoryroom_pixels, { x, y })
+  return true
+end
+replace_color(biome_boss_victoryroom, biome_lava, get_victoryroom)
+
+local function check_around_victoryroom(x, y)
+  for _, pos in ipairs(victoryroom_pixels) do
+    if x >= pos[1] - 1 and x <= pos[1] + 1 and y >= pos[2] - 1 and y <= pos[2] + 1 then
+      return true
+    end
+  end
+  return false
+end
+replace_color(biome_solid_wall_temple, biome_lava, check_around_victoryroom)

--- a/files/scripts/ascensions/a20.lua
+++ b/files/scripts/ascensions/a20.lua
@@ -21,6 +21,7 @@ function ascension:on_activate()
     "data/scripts/biomes/mountain/mountain_floating_island.lua",
     "mods/kaleva_koetus/files/scripts/appends/mountain_floating_island.lua"
   )
+  ModLuaFileAppend("data/scripts/biome_map.lua", "mods/kaleva_koetus/files/scripts/appends/biome_map.lua")
 
   if ModIsEnabled("nightmare") then
     ModLuaFileAppend(


### PR DESCRIPTION
This is a straightforward fix for #39.

It removes the victory room from the world in NG0 when the A20 ascension is active, preventing players from prematurely ending their run.

This is implemented via a single script append to biome_map.lua. This approach makes it easy to revert or replace in the future if a more complex "penalty" mechanic is designed.