### PR TITLE
:sparkles: feat(a11): Implement custom error handler for nxml parsing

### DIFF
--- a/files/scripts/lib/utils/nxml_helper.lua
+++ b/files/scripts/lib/utils/nxml_helper.lua
@@ -1,0 +1,53 @@
+local NxmlHelper = {}
+
+local ignorable_errors = {
+  duplicate_attribute = true,
+  missing_equals_sign = true,
+  missing_attribute_value = true,
+}
+
+---@class error_tracker
+---@field error_handler fun(type:string, msg:string)
+---@field has_critical_error fun()
+---@field reset fun()
+
+---@return error_tracker
+function NxmlHelper.create_error_tracker()
+  local error_tracker = {}
+  local critical_error_encountered = false
+
+  function error_tracker.error_handler(type, msg)
+    if ignorable_errors[type] == true then
+      return
+    end
+    critical_error_encountered = true
+    print("parser error: [" .. type .. "] " .. msg)
+  end
+
+  function error_tracker.has_critical_error()
+    return critical_error_encountered
+  end
+
+  function error_tracker.reset()
+    critical_error_encountered = false
+  end
+
+  return error_tracker
+end
+
+function NxmlHelper.using_error_handler(nxml_instance, error_handler, process_func)
+  local old_error_handler = nxml_instance.error_handler
+  nxml_instance.error_handler = error_handler
+
+  local results = { pcall(process_func) }
+
+  nxml_instance.error_handler = old_error_handler
+
+  if results[1] == true then
+    return unpack(results, 2)
+  else
+    error(results[2])
+  end
+end
+
+return NxmlHelper


### PR DESCRIPTION
This PR resolves #21 by introducing `NxmlHelper`, a new utility to provide robust error handling for the `nxml` parsing library.

Previously, the parser would output benign warnings from malformed vanilla XML files, creating unnecessary noise during debugging. This change introduces a wrapper around the parsing process to manage errors more gracefully.

### Key Changes:

1.  **Selective Error Suppression**:
    The new handler maintains a safelist of three specific, non-critical error types: `duplicate_attribute`, `missing_equals_sign`, and `missing_attribute_value`. These are considered safe to ignore because, according to `nxml`'s internal logic, they are localized errors that could hardly corrupt the entire DOM tree.

2.  **Critical Error Detection**:
    If any other error type is encountered, it is flagged as critical. This implementation does not alter `nxml`'s parsing behavior itself, but it allows the calling code (A11's logic) to detect that a critical error occurred and safely discard the potentially corrupted parsing result.

### Architectural Notes

The design of `NxmlHelper` explicitly accounts for the caching behavior of Noita's `dofile_once`. Since `dofile_once` caches the return value for a given file path, any module that returns a table effectively returns a **singleton reference** that is shared across the entire VM. Relying on a stateful module in this context can lead to unexpected behavior. To mitigate this:

*   `create_error_tracker` is implemented as a **factory function**. It returns a new, stateful tracker instance on each call, ensuring that state is not shared between different parsing operations.
*   `using_error_handler` utilizes **dependency injection**, requiring the `nxml` instance to be passed in explicitly. This avoids relying on a potentially shared, state-altered global instance.

### Context

This improvement is being implemented now as it is a prerequisite for the upcoming fix for **#37**. For this reason, `NxmlHelper` has been created as a separate, reusable utility rather than being tightly coupled with the A11 logic.

---
Fixes #21