### PR TITLE
:hammer: fix(AscensionManager): Remove perk_entity tag from info entity

### DIFF
--- a/files/scripts/ascension_manager.lua
+++ b/files/scripts/ascension_manager.lua
@@ -116,12 +116,11 @@ function AscensionManager:_can_unlock_next_level()
 end
 
 -- TODO:
-function AscensionManager:_add_ascension_info_park(player_entity_id)
+function AscensionManager:_add_ascension_info_perk(player_entity_id)
   local ascension_perk_added = GlobalsGetValue("kaleva_koetus_ascension_perk_added", "false") == "true"
   if not ascension_perk_added then
     -- 処理
-    local entity_ui = EntityCreateNew("")
-    EntityAddTag(entity_ui, "perk_entity")
+    local entity_ui = EntityCreateNew("kaleva_koetus_ascension_info")
 
     local description = ""
     for i = 1, self.current_level, 1 do
@@ -192,7 +191,7 @@ function AscensionManager:on_player_spawn(player_entity_id)
   end
 
   if ModSettingGet("kaleva_koetus.show_ascension_info") then
-    AscensionManager:_add_ascension_info_park(player_entity_id)
+    AscensionManager:_add_ascension_info_perk(player_entity_id)
   end
 
   for _, ascension in ipairs(self.active_ascensions) do


### PR DESCRIPTION
This PR fixes an issue where the Ascension info entities could be incorrectly removed by the vanilla game's logic.

#### Changes in `files/scripts/ascension_manager.lua`:

1.  **Tag Removal**: The `perk_entity` tag is no longer added to the info entities created by the `AscensionManager:_add_ascension_info_perk` function. This prevents them from being targeted by the game's `IMPL_remove_all_perks` function.
2.  **Entity Naming**: The info entity is now explicitly named `"kaleva_koetus_ascension_info"` instead of being an empty string.
3.  **Typo Fixes**: Corrected two instances where `_add_ascension_info_perk` was misspelled as `...park`.

---
Fixes #55