### PR TITLE
:sparkles: feat(a15): Add dynamic localization for spell names

### DIFF
--- a/files/scripts/appends/gun_actions.lua
+++ b/files/scripts/appends/gun_actions.lua
@@ -1,28 +1,11 @@
 local RandomUtils = dofile_once("mods/kaleva_koetus/files/scripts/ascensions/a15_random_utils.lua")
 
--- Localise
-local function kaleva_koetus_broken_spell_text()
-  local current_language = GameTextGet("$current_language")
-
-  local translations = {
-    ["English"] = "Incomplete ",
-    ["русский"] = "Неполное ",
-    ["Português (Brasil)"] = "Incompleto ",
-    ["Español"] = "Incompleto ",
-    ["Deutsch"] = "Unvollständig ",
-    ["Français"] = "Incomplet ",
-    ["Italiano"] = "Incompleto ",
-    ["Polska"] = "Niekompletne ",
-    ["简体中文"] = "未完成的",
-    ["日本語"] = "未完成の",
-    ["한국어"] = "불완전한",
-  }
-
-  return translations[current_language] or translations["English"]
-end
-
 local function a15_action(action)
-  action.name = kaleva_koetus_broken_spell_text() .. GameTextGetTranslatedOrNot(action.name)
+  if action.name ~= nil and string.sub(action.name, 1, 1) == "$" then
+    action.name = "$kaleva_koetus_a15_" .. string.sub(action.name, 2)
+  else
+    action.name = "$kaleva_koetus_a15_" .. action.id
+  end
 
   local rnd = math.random()
 

--- a/files/scripts/ascensions/a15.lua
+++ b/files/scripts/ascensions/a15.lua
@@ -1,3 +1,6 @@
+---@type common_csv
+local common_csv = dofile_once("mods/kaleva_koetus/files/scripts/lib/common_csv.lua")
+
 -- local Logger = dofile_once("mods/kaleva_koetus/files/scripts/lib/logger.lua")
 local AscensionBase = dofile_once("mods/kaleva_koetus/files/scripts/ascensions/ascension_subscriber.lua")
 local EventDefs = dofile_once("mods/kaleva_koetus/files/scripts/event_hub/event_types.lua")
@@ -25,6 +28,36 @@ function ascension:on_mod_post_init()
   local actions_seed = RandomUtils.derive_seed("gun_actions")
   math.randomseed(actions_seed)
 
+  local translated_prefixes = {
+    ["en"] = "Incomplete ",
+    ["ru"] = "Неполное ",
+    ["pt-br"] = "Incompleto ",
+    ["es-es"] = "Incompleto ",
+    ["de"] = "Unvollständig ",
+    ["fr-fr"] = "Incomplet ",
+    ["it"] = "Incompleto ",
+    ["pl"] = "Niekompletne ",
+    ["zh-cn"] = "未完成的",
+    ["jp"] = "未完成の",
+    ["ko"] = "불완전한",
+  }
+  local common_text = ModTextFileGetContent("data/translations/common.csv")
+  local parsed_common = common_csv.parse(common_text)
+
+  local language_line = parsed_common:line(1)
+  local prefixes = {}
+  local min_columns = 1
+  for index = 2, #language_line do
+    local language = language_line[index]
+    if language == "" then
+      break
+    end
+    prefixes[index - 1] = translated_prefixes[language] or translated_prefixes["en"]
+    min_columns = index
+  end
+
+  local common_add = {}
+
   local _ = dofile_once("data/scripts/gun/gun_actions.lua")
   -- selene: allow(undefined_variable)
   local actions = actions
@@ -33,7 +66,6 @@ function ascension:on_mod_post_init()
   for _, index in ipairs(target_indexes) do
     if actions[index].id ~= "MANA_REDUCE" then
       local id, x, y = ModImageMakeEditable(actions[index].sprite, 0, 0)
-
       for i = 0, x, 1 do
         for j = 0, y, 1 do
           local color = ModImageGetPixel(id, i, j)
@@ -41,39 +73,52 @@ function ascension:on_mod_post_init()
           ModImageSetPixel(id, i, j, inverted)
         end
       end
+
+      local name = actions[index].name
+      local extended_translations
+      if name ~= nil and string.sub(name, 1, 1) == "$" then
+        local key = string.sub(name, 2)
+        local translations = parsed_common:query(key)
+        extended_translations = { "kaleva_koetus_a15_" .. key }
+        if translations ~= nil then
+          local column_count = #translations
+          for col, prefix in ipairs(prefixes) do
+            local base_translation
+            if col <= column_count then
+              base_translation = translations[col]
+              if base_translation == "" then
+                base_translation = translations[1]
+              end
+            else
+              base_translation = translations[1]
+            end
+            extended_translations[col + 1] = prefix .. base_translation
+          end
+        else
+          for col, prefix in ipairs(prefixes) do
+            extended_translations[col + 1] = prefix .. actions[index].id
+          end
+        end
+      else
+        extended_translations = { "kaleva_koetus_a15_" .. actions[index].id }
+        for col, prefix in ipairs(prefixes) do
+          extended_translations[col + 1] = prefix
+            .. string.gsub(name, '"+', function(match)
+              if #match % 2 == 1 then
+                return match .. '"'
+              else
+                return match
+              end
+            end)
+        end
+      end
+      table.insert(common_add, extended_translations)
     end
   end
+  parsed_common:append(common_add, min_columns)
+  ModTextFileSetContent("data/translations/common.csv", tostring(parsed_common))
 
   ModLuaFileAppend("data/scripts/gun/gun_actions.lua", "mods/kaleva_koetus/files/scripts/appends/gun_actions.lua")
-end
-
-local function rename_spell(spell_entity_id)
-  local _ = dofile_once("data/scripts/gun/gun_actions.lua")
-  -- selene: allow(undefined_variable)
-  local actions = actions
-  local item_action_component_id = EntityGetFirstComponentIncludingDisabled(spell_entity_id, "ItemActionComponent")
-  local action_id = ComponentGetValue2(item_action_component_id, "action_id")
-
-  local ability_component_id = EntityGetFirstComponentIncludingDisabled(spell_entity_id, "AbilityComponent")
-
-  if ability_component_id and action_id then
-    for _, action in ipairs(actions) do
-      if action.id == action_id then
-        local action_name = GameTextGetTranslatedOrNot("$kaleva_koetus_broken_spell") .. GameTextGetTranslatedOrNot(action.name)
-        ComponentSetValue2(ability_component_id, "ui_name", action_name)
-      end
-    end
-  end
-end
-
-function ascension:on_spell_generated(payload)
-  local spell_entity_id = tonumber(payload[1])
-
-  if not spell_entity_id or spell_entity_id == 0 or EntityHasTag(spell_entity_id, ascension.tag_name) then
-    return
-  end
-
-  rename_spell(spell_entity_id)
 end
 
 return ascension

--- a/files/scripts/lib/common_csv.lua
+++ b/files/scripts/lib/common_csv.lua
@@ -1,0 +1,320 @@
+---@class common_csv
+local common_csv = {}
+
+---@class parsed_csv
+---@field _csv string
+---@field _data table
+---@field _lines table
+local parsed_csv = {}
+parsed_csv.__index = parsed_csv
+parsed_csv.__tostring = function(self)
+  return self._csv
+end
+
+---@param csv_string string
+---@param start_pos number
+---@param finish_pos number
+---@return string|nil
+---@return number|nil
+local function _next(csv_string, start_pos, finish_pos)
+  if start_pos > finish_pos then
+    return nil
+  end
+
+  local in_quotes = false
+  local i = start_pos
+
+  while i <= finish_pos do
+    local byte = csv_string:byte(i)
+
+    if byte == 34 --[[ '"' ]] then
+      if i < finish_pos and csv_string:byte(i + 1) == 34 then
+        i = i + 1
+      else
+        if in_quotes == true then
+          return csv_string:sub(start_pos, i - 1), i + 2
+        else
+          in_quotes = true
+          start_pos = i + 1
+        end
+      end
+    elseif in_quotes == false and byte == 44 --[[ ',' ]] then
+      return csv_string:sub(start_pos, i - 1), i + 1
+    end
+    i = i + 1
+  end
+
+  return nil
+end
+
+---@param csv_string string
+---@return parsed_csv
+function common_csv.parse(csv_string)
+  local parser = setmetatable({}, parsed_csv)
+  parser._csv = csv_string
+  parser._data = {}
+  parser._lines = {}
+
+  local len = #csv_string
+  if len == 0 then
+    return parser
+  end
+
+  local pos = 1
+  while pos <= len do
+    local line_end_pos
+    local next_line_start = csv_string:find('\n', pos)
+    if next_line_start ~= nil then
+      if csv_string:byte(next_line_start - 1) == 13 --[[ '\r' ]] then
+        line_end_pos = next_line_start - 2
+      else
+        line_end_pos = next_line_start - 1
+      end
+    else
+      line_end_pos = len
+      next_line_start = len
+    end
+
+    if pos > line_end_pos then
+      break
+    end
+
+    local key, value_start = _next(csv_string, pos, line_end_pos)
+    if key ~= nil and key ~= '' then
+      parser._data[key] = { value_start, line_end_pos }
+    end
+
+    table.insert(parser._lines, { pos, line_end_pos })
+
+    pos = next_line_start + 1
+  end
+
+  return parser
+end
+
+---@param key string
+---@return string[]|nil
+function parsed_csv:query(key)
+  local csv_string = self._csv
+  local indices = self._data[key]
+
+  if indices == nil then
+    return nil
+  end
+
+  local current_pos, finish_pos = indices[1], indices[2]
+  local results = {}
+
+  local field
+  while current_pos <= finish_pos do
+    field, current_pos = _next(csv_string, current_pos, finish_pos)
+
+    if field == nil then
+      break
+    end
+
+    table.insert(results, field)
+  end
+
+  return results
+end
+
+---@param index number
+---@return string[]|nil
+function parsed_csv:line(index)
+  local csv_string = self._csv
+  local indices = self._lines[index]
+
+  if indices == nil then
+    return nil
+  end
+
+  local current_pos, finish_pos = indices[1], indices[2]
+  local results = {}
+
+  local field
+  while current_pos <= finish_pos do
+    field, current_pos = _next(csv_string, current_pos, finish_pos)
+
+    if field == nil then
+      break
+    end
+
+    table.insert(results, field)
+  end
+
+  return results
+end
+
+---@param data_table table
+---@param min_columns number|nil
+function parsed_csv:append(data_table, min_columns)
+  local new_csv_part = common_csv.build_csv(data_table, min_columns)
+
+  if new_csv_part == '' then
+    return
+  end
+
+  local old_csv = self._csv
+  local end_pos = 0
+
+  if #self._lines > 0 then
+    end_pos = self._lines[#self._lines][2]
+  end
+
+  local splice_pos = old_csv:find('\n', end_pos, true)
+  if splice_pos == nil then
+    splice_pos = end_pos
+  end
+
+  local offset
+  local new_csv_full
+  if splice_pos == nil then
+    offset = end_pos + 1
+    local old_csv_part = old_csv:sub(1, end_pos)
+    new_csv_full = old_csv_part .. '\n' .. new_csv_part
+  else
+    offset = splice_pos
+    local old_csv_part = old_csv:sub(1, splice_pos)
+    new_csv_full = old_csv_part .. new_csv_part
+  end
+
+  local temp_parser = common_csv.parse(new_csv_part)
+
+  for _, line_indices in ipairs(temp_parser._lines) do
+    line_indices[1] = line_indices[1] + offset
+    line_indices[2] = line_indices[2] + offset
+    table.insert(self._lines, line_indices)
+  end
+
+  for key, value_indices in pairs(temp_parser._data) do
+    value_indices[1] = value_indices[1] + offset
+    value_indices[2] = value_indices[2] + offset
+    self._data[key] = value_indices
+  end
+
+  self._csv = new_csv_full
+end
+
+---@param field string
+---@return string|nil
+local function _process_field(field)
+  local pos = 1
+  while true do
+    local start_seq = field:find('"', pos, true)
+    if start_seq == nil then
+      break
+    end
+
+    local end_seq_pos = field:find('[^"]', start_seq + 1, true)
+
+    if end_seq_pos == nil then
+      if (#field - start_seq + 1) % 2 ~= 0 then
+        return nil
+      end
+      break
+    end
+
+    local count = end_seq_pos - start_seq
+    if count % 2 ~= 0 then
+      return nil
+    end
+
+    pos = end_seq_pos + 1
+  end
+
+  if field:find(',') then
+    return '"' .. field .. '"'
+  end
+
+  return field
+end
+
+---@param key string
+---@param value string[]
+---@param min_columns number|nil
+---@return string|nil
+function common_csv.build_line_kv(key, value, min_columns)
+  min_columns = min_columns or 0
+
+  local fields = {}
+
+  local processed_field = _process_field(key)
+  if processed_field == nil then
+    return nil
+  end
+  table.insert(fields, processed_field)
+
+  local column_count = 1
+  for _, field in ipairs(value) do
+    processed_field = _process_field(field)
+    if processed_field == nil then
+      return nil
+    end
+    table.insert(fields, processed_field)
+    column_count = column_count + 1
+  end
+
+  if column_count < min_columns then
+    table.insert(fields, string.rep(',', min_columns - column_count - 1))
+  end
+
+  table.insert(fields, "")
+
+  return table.concat(fields, ",")
+end
+
+---@param value string[]
+---@param min_columns number|nil
+---@return string|nil
+function common_csv.build_line_array(value, min_columns)
+  min_columns = min_columns or 0
+
+  local fields = {}
+
+  local column_count = 0
+  for _, field in ipairs(value) do
+    local processed_field = _process_field(field)
+    if processed_field == nil then
+      return nil
+    end
+    table.insert(fields, processed_field)
+    column_count = column_count + 1
+  end
+
+  if column_count < min_columns then
+    table.insert(fields, string.rep(',', min_columns - column_count - 1))
+  end
+
+  table.insert(fields, "")
+
+  return table.concat(fields, ",")
+end
+
+---@param data_table table
+---@param min_columns number|nil
+---@return string
+function common_csv.build_csv(data_table, min_columns)
+  local lines = {}
+
+  local array_keys = {}
+  for index, value in ipairs(data_table) do
+    array_keys[index] = true
+    local line = common_csv.build_line_array(value, min_columns)
+    if line ~= nil then
+      table.insert(lines, line)
+    end
+  end
+  for key, value in pairs(data_table) do
+    if array_keys[key] ~= true then
+      local line = common_csv.build_line_kv(key, value, min_columns)
+      if line ~= nil then
+        table.insert(lines, line)
+      end
+    end
+  end
+  table.insert(lines, "")
+  return table.concat(lines, "\n")
+end
+
+return common_csv

--- a/init.lua
+++ b/init.lua
@@ -13,7 +13,7 @@ local _ = dofile_once("data/scripts/lib/coroutines.lua")
 local ascensionManager = dofile_once("mods/kaleva_koetus/files/scripts/ascension_manager.lua")
 local eventBroker = dofile_once("mods/kaleva_koetus/files/scripts/event_hub/event_broker.lua")
 local EnemyDetector = dofile_once("mods/kaleva_koetus/files/scripts/enemy_detector.lua")
-local SpellDetector = dofile_once("mods/kaleva_koetus/files/scripts/spell_detector.lua")
+-- local SpellDetector = dofile_once("mods/kaleva_koetus/files/scripts/spell_detector.lua")
 local ImageEditor = dofile_once("mods/kaleva_koetus/files/scripts/image_editor.lua")
 
 local mark_enemy_as_processed
@@ -41,7 +41,7 @@ end
 function OnWorldInitialized()
   eventBroker:init()
   EnemyDetector:init("from_init")
-  SpellDetector:init("from_init")
+  -- SpellDetector:init("from_init")
 
   mark_enemy_as_processed = EnemyDetector:get_processed_marker()
 
@@ -81,10 +81,10 @@ function OnWorldPreUpdate()
     eventBroker:direct_dispatch(EventTypes.ENEMY_POST_SPAWN, enemy_data.id, enemy_data.x, enemy_data.y)
   end
 
-  local unprocessed_spells = SpellDetector:get_unprocessed_spells()
-  for _, spell_data in ipairs(unprocessed_spells) do
-    eventBroker:publish_event_sync("init", EventTypes.SPELL_GENERATED, spell_data.id)
-  end
+  -- local unprocessed_spells = SpellDetector:get_unprocessed_spells()
+  -- for _, spell_data in ipairs(unprocessed_spells) do
+  --   eventBroker:publish_event_sync("init", EventTypes.SPELL_GENERATED, spell_data.id)
+  -- end
 
   eventBroker:flush_event_queue()
 


### PR DESCRIPTION
This PR replaces the localization implementation for A15's "Incomplete Spell" mechanic to resolve the issue in #34, ensuring spell names update correctly when the in-game language is switched.

### The Problem
The previous method worked at runtime by first getting the fully translated string of a spell's name, and then concatenating it with a pre-translated "Incomplete" prefix. This created a final, static string that was detached from the game's localization system and could not update dynamically.

### The Solution: Init-Time Translation Generation

This has been addressed with a new, robust approach that generates all necessary translations during the `OnModPostInit` phase.

1.  **New `common_csv` Library**: A new utility has been introduced to handle CSV data. Since Noita's engine uses non-standard parsing rules that vary per file, this library is specifically designed to mimic the engine's behavior for `common.csv` and provides helper methods for reading and writing its data.

2.  **Dynamic Translation Generation**: The A15 logic now uses this library to:
    *   Read the game's existing `common.csv`.
    *   For every spell affected by A15, it dynamically creates a new translation key. For spells with an existing key (e.g., `$action_light_bullet`), it creates a new one like `$kaleva_koetus_a15_action_light_bullet`. For spells with a static name, it uses their `action.id` to create the new key.
    *   It then constructs a full translation entry for this new key, prepending the corresponding localized "Incomplete" prefix to the spell's base name for each available language.
    *   Finally, it appends all these new entries to the CSV data and writes the modified content back using `ModTextFileSetContent`.

3.  **Simplified Spell Modification**: The `gun_actions.lua` append is now much simpler. It no longer handles localization; it merely points the spell's `name` field to the new, dynamically generated translation key.

### Additional Notes
The runtime `SpellDetector` and the `SPELL_GENERATED` event are no longer necessary for A15's functionality. Since no other features currently use this event, the `SpellDetector`'s usage and event dispatching have been commented out in `init.lua`. The underlying code is being kept for now in case it is needed in the future.

---
Fixes #34