### PR TITLE
:hammer: fix(a17): Improve follower logic and radar functionality

### DIFF
--- a/files/entities/misc/following_friend.xml
+++ b/files/entities/misc/following_friend.xml
@@ -1,5 +1,7 @@
 <Entity tags="glue_NOT" name="following_friend">
 
+  <!-- NOTE: VariableStorageComponent (owner_id, target_x, target_y) added in a17.lua, ascension:on_player_spawn() -->
+
   <LightComponent
     _enabled="1"
     radius="32"
@@ -73,10 +75,4 @@
     emission_interval_max_frames="20"
     is_emitting="1">
   </ParticleEmitterComponent>
-
-  <VariableStorageComponent
-    name="memory"
-    value_int="0"
-  >
-  </VariableStorageComponent>
 </Entity>

--- a/files/scripts/ascensions/a17.lua
+++ b/files/scripts/ascensions/a17.lua
@@ -38,10 +38,11 @@ function ascension:on_activate()
   end
 
   for content in nxml.edit_file("data/entities/animals/boss_centipede/sampo.xml") do
-    content:create_child(
-      "LuaComponent",
-      { script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a17_sampo_pickup_option.lua", execute_every_n_frame = "10" }
-    )
+    content:create_child("LuaComponent", {
+      script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a17_sampo_pickup_option.lua",
+      execute_on_added = "1",
+      execute_every_n_frame = "1",
+    })
   end
 end
 
@@ -49,24 +50,33 @@ function ascension:on_player_spawn(player_entity_id)
   local friend_not_spawned = GlobalsGetValue("kaleva_koetus.a17_friend_not_spawned", "true") == "true"
   if friend_not_spawned then
     local x, y = EntityGetTransform(player_entity_id)
-    local _ = EntityAddComponent2(player_entity_id, "LuaComponent", {
-      script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a17_friend_radar.lua",
-      execute_every_n_frame = 1,
-    })
+
     local friend_entity_id = EntityLoad("mods/kaleva_koetus/files/entities/misc/following_friend.xml", x, y)
     EntityAddTag(friend_entity_id, "kk_a17_friend")
     local _ = EntityAddComponent2(friend_entity_id, "VariableStorageComponent", {
       name = "owner_id",
       value_int = player_entity_id,
     })
-    local _ = EntityAddComponent2(player_entity_id, "LuaComponent", {
-      script_portal_teleport_used = "mods/kaleva_koetus/files/scripts/ascensions/a17_player_portal_teleported.lua",
-      execute_every_n_frame = -1,
+    _ = EntityAddComponent2(friend_entity_id, "VariableStorageComponent", {
+      name = "target_x",
+      value_float = x,
     })
-    local _ = EntityAddComponent2(player_entity_id, "LuaComponent", {
+    _ = EntityAddComponent2(friend_entity_id, "VariableStorageComponent", {
+      name = "target_y",
+      value_float = y,
+    })
+    GlobalsSetValue("kaleva_koetus.a17_friend_last_x", tostring(x))
+    GlobalsSetValue("kaleva_koetus.a17_friend_last_y", tostring(y))
+
+    _ = EntityAddComponent2(player_entity_id, "LuaComponent", {
+      script_source_file = "mods/kaleva_koetus/files/scripts/ascensions/a17_friend_radar.lua",
+      execute_every_n_frame = 1,
+    })
+    _ = EntityAddComponent2(player_entity_id, "LuaComponent", {
       script_teleported = "mods/kaleva_koetus/files/scripts/ascensions/a17_player_portal_teleported.lua",
       execute_every_n_frame = -1,
     })
+
     GlobalsSetValue("kaleva_koetus.a17_friend_not_spawned", "false")
   end
 end

--- a/files/scripts/ascensions/a17_friend_movement.lua
+++ b/files/scripts/ascensions/a17_friend_movement.lua
@@ -1,27 +1,73 @@
 local _ = dofile_once("mods/kaleva_koetus/files/scripts/lib/utils/player.lua")
 local _ = dofile_once("data/scripts/lib/utilities.lua")
 
-local entity_id = GetUpdatedEntityID()
-local x, y = EntityGetTransform(entity_id)
-local px, py = x, y
-local owner_id = GetPlayerEntity()
-
-local comps = EntityGetComponent(entity_id, "VariableStorageComponent")
+local max_distance = 200
 local swaying = true
 
+local entity_id = GetUpdatedEntityID()
+
+local radar_x, radar_y = EntityGetFirstHitboxCenter(entity_id)
+GlobalsSetValue("kaleva_koetus.a17_friend_last_x", tostring(radar_x))
+GlobalsSetValue("kaleva_koetus.a17_friend_last_y", tostring(radar_y))
+
+local x, y = EntityGetTransform(entity_id)
+local px, py
+
+local comps = EntityGetComponent(entity_id, "VariableStorageComponent")
 if comps ~= nil then
+  local owner_id
+  local owner_id_comp, target_x_comp, target_y_comp
   for _, v in ipairs(comps) do
     local name = ComponentGetValue2(v, "name")
-
     if name == "owner_id" then
-      px, py = EntityGetTransform(owner_id)
+      owner_id_comp = v
+    elseif name == "target_x" then
+      target_x_comp = v
+    elseif name == "target_y" then
+      target_y_comp = v
+    end
 
-      if (px == nil) or (py == nil) then
-        px, py = x, y
+    if owner_id_comp ~= nil then
+      local temp_owner_id = ComponentGetValue2(owner_id_comp, "value_int")
+      if EntityGetIsAlive(temp_owner_id) == true then
+        owner_id = temp_owner_id
+        px, py = EntityGetTransform(owner_id)
+      end
+    end
+
+    if owner_id == nil then
+      local temp_owner_id = GetPlayerEntity()
+      if temp_owner_id ~= nil and EntityGetIsAlive(temp_owner_id) == true then
+        owner_id = temp_owner_id
+        px, py = EntityGetTransform(owner_id)
+        if owner_id_comp ~= nil then
+          ComponentSetValue2(owner_id_comp, "value_int", owner_id)
+        end
+      end
+    end
+
+    if owner_id == nil then
+      px = target_x_comp ~= nil and ComponentGetValue2(target_x_comp, "value_float") or x
+      py = target_y_comp ~= nil and ComponentGetValue2(target_y_comp, "value_float") or y
+    else
+      if target_x_comp ~= nil then
+        ComponentSetValue2(target_x_comp, "value_float", px)
+      end
+      if target_y_comp ~= nil then
+        ComponentSetValue2(target_y_comp, "value_float", py)
       end
     end
   end
 end
+
+-- selene: allow(undefined_variable)
+local dist = get_distance(x, y, px, py)
+if dist >= max_distance then
+  PhysicsSetStatic(entity_id, true)
+  return
+end
+
+PhysicsSetStatic(entity_id, false)
 
 local cvx, cvy = 0, 0
 local physcomp = EntityGetFirstComponent(entity_id, "PhysicsBodyComponent")
@@ -40,7 +86,7 @@ end
 -- selene: allow(undefined_variable)
 local dir = get_direction(x, y, px, py)
 -- selene: allow(undefined_variable)
-local dist = math.min(get_distance(x, y, px, py), 32)
+dist = math.min(get_distance(x, y, px, py), 32)
 
 local vel_x = 0 - (math.cos(dir) * dist)
 local vel_y = 0 - (0 - math.sin(dir) * dist)
@@ -54,16 +100,3 @@ if ((y > py) and (cvy > 0)) or ((y < py) and (cvy < 0)) then
 end
 
 PhysicsApplyForce(entity_id, vel_x, vel_y)
-
-if owner_id ~= 0 then
-  x, y = EntityGetTransform(entity_id)
-  local ox, oy = EntityGetTransform(owner_id)
-  dist = math.abs(x - ox) + math.abs(y - oy)
-
-  if dist < 300 then
-    PhysicsApplyForce(entity_id, vel_x, vel_y)
-    PhysicsSetStatic(entity_id, false)
-  else
-    PhysicsSetStatic(entity_id, true)
-  end
-end

--- a/files/scripts/ascensions/a17_friend_radar.lua
+++ b/files/scripts/ascensions/a17_friend_radar.lua
@@ -1,67 +1,79 @@
 local _ = dofile_once("data/scripts/lib/utilities.lua")
 
 local entity_id = GetUpdatedEntityID()
+if ModSettingGet("kaleva_koetus.a20_dead_boss") or ((tonumber(SessionNumbersGetValue("NEW_GAME_PLUS_COUNT")) or 0) > 0) then
+  local lua_component_id = GetUpdatedComponentID()
+  EntityRemoveComponent(entity_id, lua_component_id)
+  return
+end
+
 local pos_x, pos_y = EntityGetTransform(entity_id)
 pos_y = pos_y - 4 -- offset to middle of character
 
 local range = 1000
 local indicator_distance = 40
 
--- ping nearby enemies
-for _, friend_id in pairs(EntityGetInRadiusWithTag(pos_x, pos_y, range, "kk_a17_friend")) do
-  local enemy_x, enemy_y = EntityGetFirstHitboxCenter(friend_id)
-  local dir_x = enemy_x - pos_x
-  local dir_y = enemy_y - pos_y
+local enemy_x, enemy_y
+
+local friend_id = EntityGetClosestWithTag(pos_x, pos_y, "kk_a17_friend")
+if friend_id ~= nil and friend_id ~= 0 then
+  enemy_x, enemy_y = EntityGetFirstHitboxCenter(friend_id)
+else
+  enemy_x = tonumber(GlobalsGetValue("kaleva_koetus.a17_friend_last_x")) or pos_x
+  enemy_y = tonumber(GlobalsGetValue("kaleva_koetus.a17_friend_last_y")) or pos_y
+end
+
+local dir_x = enemy_x - pos_x
+local dir_y = enemy_y - pos_y
+-- selene: allow(undefined_variable)
+local distance = get_magnitude(dir_x, dir_y)
+
+local indicator_x = 0
+local indicator_y = 0
+
+-- selene: allow(undefined_variable)
+if is_in_camera_bounds(enemy_x, enemy_y, -4) then
+  indicator_x = enemy_x
+  indicator_y = enemy_y - 3
+else
   -- selene: allow(undefined_variable)
-  local distance = get_magnitude(dir_x, dir_y)
+  dir_x, dir_y = vec_normalize(dir_x, dir_y)
+  indicator_x = pos_x + dir_x * indicator_distance
+  indicator_y = pos_y + dir_y * indicator_distance
+end
 
-  local indicator_x = 0
-  local indicator_y = 0
-
-  -- selene: allow(undefined_variable)
-  if is_in_camera_bounds(enemy_x, enemy_y, -4) then
-    indicator_x = enemy_x
-    indicator_y = enemy_y - 3
-  else
-    -- selene: allow(undefined_variable)
-    dir_x, dir_y = vec_normalize(dir_x, dir_y)
-    indicator_x = pos_x + dir_x * indicator_distance
-    indicator_y = pos_y + dir_y * indicator_distance
-  end
-
-  -- display sprite based on proximity
-  if distance > range * 0.8 then
-    GameCreateSpriteForXFrames(
-      "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_faint.png",
-      indicator_x,
-      indicator_y,
-      true,
-      0,
-      0,
-      1,
-      true
-    )
-  elseif distance > range * 0.5 then
-    GameCreateSpriteForXFrames(
-      "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_medium.png",
-      indicator_x,
-      indicator_y,
-      true,
-      0,
-      0,
-      1,
-      true
-    )
-  else
-    GameCreateSpriteForXFrames(
-      "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_strong.png",
-      indicator_x,
-      indicator_y,
-      true,
-      0,
-      0,
-      1,
-      true
-    )
-  end
+-- display sprite based on proximity
+if distance > range * 0.8 then
+  GameCreateSpriteForXFrames(
+    "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_faint.png",
+    indicator_x,
+    indicator_y,
+    true,
+    0,
+    0,
+    1,
+    true
+  )
+elseif distance > range * 0.5 then
+  GameCreateSpriteForXFrames(
+    "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_medium.png",
+    indicator_x,
+    indicator_y,
+    true,
+    0,
+    0,
+    1,
+    true
+  )
+else
+  GameCreateSpriteForXFrames(
+    "mods/kaleva_koetus/tmp/a17/data/particles/radar_enemy_strong.png",
+    indicator_x,
+    indicator_y,
+    true,
+    0,
+    0,
+    1,
+    true
+  )
 end

--- a/files/scripts/ascensions/a17_sampo_pickup_option.lua
+++ b/files/scripts/ascensions/a17_sampo_pickup_option.lua
@@ -1,24 +1,37 @@
 local _ = dofile_once("mods/kaleva_koetus/files/scripts/lib/utils/player.lua")
 
+local sampo_entity_id = GetUpdatedEntityID()
+local item_component_id = EntityGetFirstComponentIncludingDisabled(sampo_entity_id, "ItemComponent")
+if ModSettingGet("kaleva_koetus.a20_dead_boss") or ((tonumber(SessionNumbersGetValue("NEW_GAME_PLUS_COUNT")) or 0) > 0) then
+  ComponentSetValue2(item_component_id, "is_pickable", true)
+  local lua_component_id = GetUpdatedComponentID()
+  EntityRemoveComponent(sampo_entity_id, lua_component_id)
+  return
+end
+
 -- NOTE:
 -- プレイヤーの座標を取って、そこから200以内にfriendがいなければ、無効化してテキストを出す
 local plyer_entity_id = GetPlayerEntity()
+if plyer_entity_id == nil or EntityGetIsAlive(plyer_entity_id) == false then
+  return
+end
+
 local x, y = EntityGetTransform(plyer_entity_id)
 local friend_entity_id = EntityGetInRadiusWithTag(x, y, 200, "kk_a17_friend")[1]
 local exist_friend = friend_entity_id and friend_entity_id ~= 0
 
-local sampo_entity_id = GetUpdatedEntityID()
-local item_component_id = EntityGetFirstComponentIncludingDisabled(sampo_entity_id, "ItemComponent")
-
-if exist_friend or ModSettingGet("kaleva_koetus.a20_dead_boss") or ((tonumber(SessionNumbersGetValue("NEW_GAME_PLUS_COUNT")) or 0) > 0) then
+if exist_friend then
   ComponentSetValue2(item_component_id, "is_pickable", true)
 else
+  ComponentSetValue2(item_component_id, "is_pickable", false)
+
   local announced = GlobalsGetValue("kaleva_koetus_a17_boss_announced", "false") == "true"
   if not announced then
-    GamePrintImportant("$kaleva_koetus_no_kindness")
-    GamePrint("$kaleva_koetus_no_kindness")
-    GlobalsSetValue("kaleva_koetus_a17_boss_announced", "true")
+    local sampo_x, sampo_y = EntityGetTransform(sampo_entity_id)
+    if ((x - sampo_x) ^ 2 + (y - sampo_y) ^ 2) ^ 0.5 <= 100 then
+      GamePrintImportant("$kaleva_koetus_no_kindness")
+      GamePrint("$kaleva_koetus_no_kindness")
+      GlobalsSetValue("kaleva_koetus_a17_boss_announced", "true")
+    end
   end
-
-  ComponentSetValue2(item_component_id, "is_pickable", false)
 end


### PR DESCRIPTION
This PR resolves #36. It addresses several known issues to improve stability, while also introducing functional changes to enhance the player experience with the A17 follower.

### Key Changes:

1.  **Follower Movement Logic (`a17_friend_movement.lua`):**
    *   **Improved Owner Detection:** The logic for finding the owner is now more robust, preventing Lua errors in edge cases where the player entity might exist but be invalid.
    *   **Persistent Target Location:** If the owner cannot be found, the follower will now move towards the owner's last known position, which is stored in its `VariableStorageComponent`s.
    *   The follower now saves its own position to Global variables.

2.  **Radar Logic (`a17_friend_radar.lua`):**
    *   **New Infinite-Range Radar:** Based on feedback about the difficulty of relocating the follower once it has been lost, the radar's functionality has been extended. It now has an effectively infinite range.
    *   **Fallback Targeting:** The radar will prioritize pointing to the follower entity's live position. If the entity cannot be found (e.g., it has been unloaded), the radar will fall back to pointing at the last known position stored in Globals. This new feature supports the infinite-range capability, ensuring the radar is always useful.

3.  **`LuaComponent` Lifecycle Management:**
    *   A superfluous `LuaComponent` on the player entity has been removed.
    *   The `LuaComponent` on the Sampo (`a17_sampo_pickup_option.lua`) now more explicitly removes itself when when the restriction no longer works.
    *   Crucially, a similar self-removal logic has been added to the radar's `LuaComponent` (`a17_friend_radar.lua`) on the player. This is a necessary fix to prevent the new infinite-range fallback from incorrectly pointing to a follower's last known location in game globals where the follower is not supposed to exist by design (such as in NG+).

These adjustments make the A17 mechanic more stable and user-friendly.

---
Fixes #36