### PR TITLE
:hammer: fix(a17): Clear cached follower owner_id on entity load

### DIFF
--- a/files/entities/misc/following_friend.xml
+++ b/files/entities/misc/following_friend.xml
@@ -1,6 +1,6 @@
 <Entity tags="glue_NOT" name="following_friend">
 
-  <!-- NOTE: VariableStorageComponent (owner_id, target_x, target_y) added in a17.lua, ascension:on_player_spawn() -->
+  <!-- NOTE: VariableStorageComponent (target_x, target_y) added in a17.lua, ascension:on_player_spawn() -->
 
   <LightComponent
     _enabled="1"
@@ -19,6 +19,16 @@
   >
   </SpriteComponent>
 
+  <VariableStorageComponent
+    name="owner_id"
+    value_int="0"
+  ></VariableStorageComponent>
+
+  <LuaComponent
+    script_source_file="mods/kaleva_koetus/files/scripts/ascensions/a17_friend_clear_owner.lua"
+    execute_on_added="1"
+    execute_every_n_frame="-1"
+  ></LuaComponent>
 
   <LuaComponent
     script_source_file="mods/kaleva_koetus/files/scripts/ascensions/a17_friend_movement.lua"

--- a/files/scripts/ascensions/a17.lua
+++ b/files/scripts/ascensions/a17.lua
@@ -53,10 +53,15 @@ function ascension:on_player_spawn(player_entity_id)
 
     local friend_entity_id = EntityLoad("mods/kaleva_koetus/files/entities/misc/following_friend.xml", x, y)
     EntityAddTag(friend_entity_id, "kk_a17_friend")
-    local _ = EntityAddComponent2(friend_entity_id, "VariableStorageComponent", {
-      name = "owner_id",
-      value_int = player_entity_id,
-    })
+    local variable_storage_components = EntityGetComponent(friend_entity_id, "VariableStorageComponent")
+    if variable_storage_components ~= nil then
+      for _, variable_storage_cid in ipairs(variable_storage_components) do
+        if ComponentGetValue2(variable_storage_cid, "name") == "owner_id" then
+          ComponentSetValue2(variable_storage_cid, "value_int", player_entity_id)
+          break
+        end
+      end
+    end
     _ = EntityAddComponent2(friend_entity_id, "VariableStorageComponent", {
       name = "target_x",
       value_float = x,

--- a/files/scripts/ascensions/a17_friend_clear_owner.lua
+++ b/files/scripts/ascensions/a17_friend_clear_owner.lua
@@ -1,0 +1,13 @@
+local entity_id = GetUpdatedEntityID()
+
+if entity_id ~= 0 then
+  local variable_storage_components = EntityGetComponent(entity_id, "VariableStorageComponent")
+  if variable_storage_components ~= nil then
+    for _, variable_storage_cid in ipairs(variable_storage_components) do
+      if ComponentGetValue2(variable_storage_cid, "name") == "owner_id" then
+        ComponentSetValue2(variable_storage_cid, "value_int", 0)
+        break
+      end
+    end
+  end
+end

--- a/files/scripts/ascensions/a17_friend_movement.lua
+++ b/files/scripts/ascensions/a17_friend_movement.lua
@@ -26,36 +26,36 @@ if comps ~= nil then
     elseif name == "target_y" then
       target_y_comp = v
     end
+  end
 
-    if owner_id_comp ~= nil then
-      local temp_owner_id = ComponentGetValue2(owner_id_comp, "value_int")
-      if EntityGetIsAlive(temp_owner_id) == true then
-        owner_id = temp_owner_id
-        px, py = EntityGetTransform(owner_id)
+  if owner_id_comp ~= nil then
+    local temp_owner_id = ComponentGetValue2(owner_id_comp, "value_int")
+    if temp_owner_id ~= 0 and EntityGetIsAlive(temp_owner_id) == true then
+      owner_id = temp_owner_id
+      px, py = EntityGetTransform(owner_id)
+    end
+  end
+
+  if owner_id == nil then
+    local temp_owner_id = GetPlayerEntity()
+    if temp_owner_id ~= nil and EntityGetIsAlive(temp_owner_id) == true then
+      owner_id = temp_owner_id
+      px, py = EntityGetTransform(owner_id)
+      if owner_id_comp ~= nil then
+        ComponentSetValue2(owner_id_comp, "value_int", owner_id)
       end
     end
+  end
 
-    if owner_id == nil then
-      local temp_owner_id = GetPlayerEntity()
-      if temp_owner_id ~= nil and EntityGetIsAlive(temp_owner_id) == true then
-        owner_id = temp_owner_id
-        px, py = EntityGetTransform(owner_id)
-        if owner_id_comp ~= nil then
-          ComponentSetValue2(owner_id_comp, "value_int", owner_id)
-        end
-      end
+  if owner_id == nil then
+    px = target_x_comp ~= nil and ComponentGetValue2(target_x_comp, "value_float") or x
+    py = target_y_comp ~= nil and ComponentGetValue2(target_y_comp, "value_float") or y
+  else
+    if target_x_comp ~= nil then
+      ComponentSetValue2(target_x_comp, "value_float", px)
     end
-
-    if owner_id == nil then
-      px = target_x_comp ~= nil and ComponentGetValue2(target_x_comp, "value_float") or x
-      py = target_y_comp ~= nil and ComponentGetValue2(target_y_comp, "value_float") or y
-    else
-      if target_x_comp ~= nil then
-        ComponentSetValue2(target_x_comp, "value_float", px)
-      end
-      if target_y_comp ~= nil then
-        ComponentSetValue2(target_y_comp, "value_float", py)
-      end
+    if target_y_comp ~= nil then
+      ComponentSetValue2(target_y_comp, "value_float", py)
     end
   end
 end


### PR DESCRIPTION
This PR resolves #64 by addressing an issue where the A17 follower could track a non-player entity after a full game restart due to a stale cached `owner_id`.

### The Fix

A new `LuaComponent` with `execute_on_added="1"` has been added to the `following_friend` entity. This script (`a17_friend_clear_owner.lua`) runs every time the entity is loaded into the world and its sole responsibility is to clear the cached `owner_id`.

This forces the existing movement logic in `a17_friend_movement.lua` to re-evaluate and acquire a new, valid player entity on its next update cycle, effectively preventing it from tracking an incorrect entity from a previous game session.

### Minor Correction

Additionally, a subtle logic error in `a17_friend_movement.lua` has been corrected.

The script is supposed to first iterate through all `VariableStorageComponent`s to find the ones it needs. After the loop, it should use the collected information to determine the target and update the storaged values accordingly. However, this decision-making and component-updating logic was incorrectly placed *inside* the iteration loop.

While this logical flaw did not cause a noticeable gameplay issue, moving the logic block to its correct position outside the loop ensures the code operates as intended.

---
Fixes #64